### PR TITLE
[BUGFIX] Updates to latest beta and new setComponentTemplate

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-typescript": "^7.9.0",
-    "@glimmer/babel-plugin-glimmer-env": "^2.0.0-beta.3",
+    "@glimmer/babel-plugin-glimmer-env": "^2.0.0-beta.5",
     "@types/qunit": "^2.9.0",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",

--- a/packages/@glimmerx/babel-plugin-component-templates/index.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/index.js
@@ -255,8 +255,8 @@ module.exports = function(babel, options) {
 
         path.replaceWith(
           t.callExpression(t.identifier(setTemplateId), [
-            t.callExpression(t.identifier(templateOnlyId), []),
             templateNode,
+            t.callExpression(t.identifier(templateOnlyId), []),
           ])
         );
       },
@@ -278,17 +278,17 @@ module.exports = function(babel, options) {
     const setTemplateId = maybeAddSetTemplateImport(state, programPath);
 
     const template = shouldPrecompile
-      ? buildTemplate(templatePath, state)
+      ? buildTemplate(templatePath)
       : buildCreateTemplate(templatePath, programPath, state);
 
     if (classPath.isClassExpression()) {
       classPath.replaceWith(
-        t.callExpression(t.identifier(setTemplateId), [classPath.node, template])
+        t.callExpression(t.identifier(setTemplateId), [template, classPath.node])
       );
     } else {
       const classId = classPath.node.id;
 
-      classPath.insertAfter(t.callExpression(t.identifier(setTemplateId), [classId, template]));
+      classPath.insertAfter(t.callExpression(t.identifier(setTemplateId), [template, classId]));
     }
   }
 
@@ -309,9 +309,9 @@ module.exports = function(babel, options) {
     return filtered;
   }
 
-  function buildTemplate(path, programPath, state) {
+  function buildTemplate(path) {
     const templateSource = getTemplateString(path);
-    const templateScopeTokens = getFilteredTemplateTokens(path, templateSource, state);
+    const templateScopeTokens = getFilteredTemplateTokens(path, templateSource);
 
     const compiledTemplate = precompileTemplate(
       templateSource,
@@ -327,7 +327,7 @@ module.exports = function(babel, options) {
   function buildCreateTemplate(path, programPath, state) {
     const createTemplateId = maybeAddCreateTemplateImport(state, programPath);
     const templateSource = getTemplateString(path);
-    const tokens = getFilteredTemplateTokens(path, templateSource, state);
+    const tokens = getFilteredTemplateTokens(path, templateSource);
 
     const scopeObject = t.objectExpression(
       tokens.map(token => t.objectProperty(t.identifier(token), t.identifier(token), false, false))

--- a/packages/@glimmerx/babel-plugin-component-templates/package.json
+++ b/packages/@glimmerx/babel-plugin-component-templates/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/core": "^7.5.5",
     "@babel/helper-module-imports": "^7.0.0",
-    "@glimmer/babel-plugin-strict-template-precompile": "^2.0.0-beta.3",
+    "@glimmer/babel-plugin-strict-template-precompile": "^2.0.0-beta.5",
     "@glimmer/syntax": "^0.50.0"
   },
   "devDependencies": {

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/class-declaration/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/class-declaration/output.js
@@ -5,6 +5,6 @@ import Component from '@glimmerx/component';
 
 class MyComponent extends Component {}
 
-_setComponentTemplate(MyComponent, _createTemplate({
+_setComponentTemplate(_createTemplate({
   _t: _t
-}, `<h1>{{_t "foo"}}</h1>`))
+}, `<h1>{{_t "foo"}}</h1>`), MyComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/class-expression/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/class-expression/output.js
@@ -3,6 +3,6 @@ import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 import { t as _t } from "t-helper";
 import Component from '@glimmerx/component';
 
-const MyComponent = _setComponentTemplate(class extends Component {}, _createTemplate({
+const MyComponent = _setComponentTemplate(_createTemplate({
   _t: _t
-}, `<h1>{{_t "foo"}}</h1>`));
+}, `<h1>{{_t "foo"}}</h1>`), class extends Component {});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/template-only-component/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/template-only-component/output.js
@@ -5,12 +5,12 @@ import { t as _t } from "t-helper";
 import OtherComponent from './OtherComponent';
 import YetAnotherComponent from './YetAnotherComponent';
 
-const template1 = _setComponentTemplate(_templateOnlyComponent(), _createTemplate({
+const template1 = _setComponentTemplate(_createTemplate({
   OtherComponent: OtherComponent,
   _t: _t
-}, `{{_t "bar"}}<h1>Hello world</h1><OtherComponent/>`));
+}, `{{_t "bar"}}<h1>Hello world</h1><OtherComponent/>`), _templateOnlyComponent());
 
-const template2 = _setComponentTemplate(_templateOnlyComponent(), _createTemplate({
+const template2 = _setComponentTemplate(_createTemplate({
   YetAnotherComponent: YetAnotherComponent,
   _t: _t
-}, `{{_t "foo"}}<YetAnotherComponent/>`));
+}, `{{_t "foo"}}<YetAnotherComponent/>`), _templateOnlyComponent());

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-declaration/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-declaration/output.js
@@ -4,7 +4,7 @@ import Component from '@glimmerx/component';
 
 class MyComponent extends Component {}
 
-_setComponentTemplate(MyComponent, {
+_setComponentTemplate({
   id: "2nwO9ZJ8",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,0,0,0,[31,6,2,[27,[26,0,\"CallHead\"],[]],[\"foo\"],null]],[11]],\"hasEval\":false,\"upvars\":[\"_t\"]}",
   meta: {
@@ -12,4 +12,4 @@ _setComponentTemplate(MyComponent, {
       _t: _t
     })
   }
-})
+}, MyComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-expression/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-expression/output.js
@@ -2,7 +2,7 @@ import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 import { t as _t } from "t-helper";
 import Component from '@glimmerx/component';
 
-const MyComponent = _setComponentTemplate(class extends Component {}, {
+const MyComponent = _setComponentTemplate({
   id: "2nwO9ZJ8",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,0,0,0,[31,6,2,[27,[26,0,\"CallHead\"],[]],[\"foo\"],null]],[11]],\"hasEval\":false,\"upvars\":[\"_t\"]}",
   meta: {
@@ -10,4 +10,4 @@ const MyComponent = _setComponentTemplate(class extends Component {}, {
       _t: _t
     })
   }
-});
+}, class extends Component {});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/template-only-component/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/template-only-component/output.js
@@ -2,7 +2,7 @@ import { templateOnlyComponent as _templateOnlyComponent } from "@glimmer/core";
 import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 import { t as _t } from "t-helper";
 
-const someTemplate = _setComponentTemplate(_templateOnlyComponent(), {
+const someTemplate = _setComponentTemplate({
   id: "2nwO9ZJ8",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,0,0,0,[31,6,2,[27,[26,0,\"CallHead\"],[]],[\"foo\"],null]],[11]],\"hasEval\":false,\"upvars\":[\"_t\"]}",
   meta: {
@@ -10,4 +10,4 @@ const someTemplate = _setComponentTemplate(_templateOnlyComponent(), {
       _t: _t
     })
   }
-});
+}, _templateOnlyComponent());

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform-hbs/output.js
@@ -1,10 +1,10 @@
 import { templateOnlyComponent as _templateOnlyComponent } from "@glimmer/core";
 import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 
-const template = _setComponentTemplate(_templateOnlyComponent(), {
+const template = _setComponentTemplate({
   id: "k5+y7pkD",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-});
+}, _templateOnlyComponent());

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/output.js
@@ -3,10 +3,10 @@ import Component from '@glimmerx/component';
 
 class MyComponent extends Component {}
 
-_setComponentTemplate(MyComponent, {
+_setComponentTemplate({
   id: "k5+y7pkD",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-})
+}, MyComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-declaration/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-declaration/output.js
@@ -7,7 +7,7 @@ const maybeModifier = null;
 
 class MyComponent extends Component {}
 
-_setComponentTemplate(MyComponent, {
+_setComponentTemplate({
   id: "hNaOsjkR",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",false],[3,0,0,[27,[26,0,\"ModifierHead\"],[]],null,null],[10],[1,1,0,0,\"Hello world \"],[1,0,0,0,[27,[26,1,\"AppendSingleId\"],[]]],[7,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[7,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[11]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
   meta: {
@@ -17,4 +17,4 @@ _setComponentTemplate(MyComponent, {
       maybeModifier: maybeModifier
     })
   }
-})
+}, MyComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-expression/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-expression/output.js
@@ -1,10 +1,10 @@
 import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 import Component from '@glimmerx/component';
 
-const MyComponent = _setComponentTemplate(class extends Component {}, {
+const MyComponent = _setComponentTemplate({
   id: "hzw7dJc0",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-});
+}, class extends Component {});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/custom-imports/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/custom-imports/output.js
@@ -4,33 +4,33 @@ import Component from '@glimmerx/component';
 
 class Class1Declaration extends Component {}
 
-_dangerouslySetComponentTemplate(Class1Declaration, {
+_dangerouslySetComponentTemplate({
   id: "hzw7dJc0",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-})
+}, Class1Declaration)
 
-const Class1Expression = _dangerouslySetComponentTemplate(class extends Component {}, {
+const Class1Expression = _dangerouslySetComponentTemplate({
   id: "hzw7dJc0",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-});
+}, class extends Component {});
 
 class Class2Declaration extends Component {}
 
-_dangerouslySetComponentTemplate(Class2Declaration, {
+_dangerouslySetComponentTemplate({
   id: "85zTPBgs",
   block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"\\n    Goodbye world\\n  \"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-})
+}, Class2Declaration)
 
-const Class2Expression = _dangerouslySetComponentTemplate(class extends Component {}, {
+const Class2Expression = _dangerouslySetComponentTemplate({
   id: "64616wXU",
   block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"\\n    Goodbye world\"],[7,\"Class2Declaration\",[],[[],[]],null],[1,1,0,0,\"\\n  \"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
@@ -38,9 +38,9 @@ const Class2Expression = _dangerouslySetComponentTemplate(class extends Componen
       Class2Declaration: Class2Declaration
     })
   }
-});
+}, class extends Component {});
 
-const TOComponent = _dangerouslySetComponentTemplate(_TOComponent(), {
+const TOComponent = _dangerouslySetComponentTemplate({
   id: "iXWF5ni9",
   block: "{\"symbols\":[],\"statements\":[[9,\"h3\",true],[10],[1,1,0,0,\"Hello again world\"],[7,\"Class2Expression\",[],[[],[]],null],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
@@ -48,4 +48,4 @@ const TOComponent = _dangerouslySetComponentTemplate(_TOComponent(), {
       Class2Expression: Class2Expression
     })
   }
-});
+}, _TOComponent());

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/glimmer-env/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/glimmer-env/output.js
@@ -12,7 +12,7 @@ if (true
 
 class MyComponent extends Component {}
 
-_setComponentTemplate(MyComponent, {
+_setComponentTemplate({
   id: "hNaOsjkR",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",false],[3,0,0,[27,[26,0,\"ModifierHead\"],[]],null,null],[10],[1,1,0,0,\"Hello world \"],[1,0,0,0,[27,[26,1,\"AppendSingleId\"],[]]],[7,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[7,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[11]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
   meta: {
@@ -22,4 +22,4 @@ _setComponentTemplate(MyComponent, {
       maybeModifier: maybeModifier
     })
   }
-})
+}, MyComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-commonjs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-commonjs/output.js
@@ -8,31 +8,31 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 class Class1Declaration extends _component.default {}
 
-(0, _core.setComponentTemplate)(Class1Declaration, {
+(0, _core.setComponentTemplate)({
   id: "hzw7dJc0",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-})
-const Class1Expression = (0, _core.setComponentTemplate)(class extends _component.default {}, {
+}, Class1Declaration)
+const Class1Expression = (0, _core.setComponentTemplate)({
   id: "hzw7dJc0",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-});
+}, class extends _component.default {});
 
 class Class2Declaration extends _component.default {}
 
-(0, _core.setComponentTemplate)(Class2Declaration, {
+(0, _core.setComponentTemplate)({
   id: "85zTPBgs",
   block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"\\n    Goodbye world\\n  \"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-})
-const Class2Expression = (0, _core.setComponentTemplate)(class extends _component.default {}, {
+}, Class2Declaration)
+const Class2Expression = (0, _core.setComponentTemplate)({
   id: "d1fbtzoG",
   block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"\\n    Goodbye world\"],[7,\"Class1Expression\",[],[[],[]],null],[1,1,0,0,\"\\n  \"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
@@ -40,4 +40,4 @@ const Class2Expression = (0, _core.setComponentTemplate)(class extends _componen
       Class1Expression: Class1Expression
     })
   }
-});
+}, class extends _component.default {});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-same-scope-var-commonjs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-same-scope-var-commonjs/output.js
@@ -10,7 +10,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 class MyComponent extends _component.default {}
 
-(0, _core.setComponentTemplate)(MyComponent, {
+(0, _core.setComponentTemplate)({
   id: "wvnbwYrJ",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello \"],[7,\"ExternalComponent\",[],[[],[]],null],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
@@ -18,11 +18,11 @@ class MyComponent extends _component.default {}
       ExternalComponent: _somewhere.OtherComponent
     })
   }
-})
+}, MyComponent)
 
 class OtherComponent extends _component.default {}
 
-(0, _core.setComponentTemplate)(OtherComponent, {
+(0, _core.setComponentTemplate)({
   id: "wvnbwYrJ",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello \"],[7,\"ExternalComponent\",[],[[],[]],null],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
@@ -30,4 +30,4 @@ class OtherComponent extends _component.default {}
       ExternalComponent: _somewhere.OtherComponent
     })
   }
-})
+}, OtherComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes/output.js
@@ -3,33 +3,33 @@ import Component from '@glimmerx/component';
 
 class Class1Declaration extends Component {}
 
-_setComponentTemplate(Class1Declaration, {
+_setComponentTemplate({
   id: "hzw7dJc0",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-})
+}, Class1Declaration)
 
-const Class1Expression = _setComponentTemplate(class extends Component {}, {
+const Class1Expression = _setComponentTemplate({
   id: "hzw7dJc0",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-});
+}, class extends Component {});
 
 class Class2Declaration extends Component {}
 
-_setComponentTemplate(Class2Declaration, {
+_setComponentTemplate({
   id: "85zTPBgs",
   block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"\\n    Goodbye world\\n  \"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-})
+}, Class2Declaration)
 
-const Class2Expression = _setComponentTemplate(class extends Component {}, {
+const Class2Expression = _setComponentTemplate({
   id: "d1fbtzoG",
   block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"\\n    Goodbye world\"],[7,\"Class1Expression\",[],[[],[]],null],[1,1,0,0,\"\\n  \"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
@@ -37,4 +37,4 @@ const Class2Expression = _setComponentTemplate(class extends Component {}, {
       Class1Expression: Class1Expression
     })
   }
-});
+}, class extends Component {});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiscope-tokens/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiscope-tokens/output.js
@@ -6,7 +6,7 @@ import SecondPhantomComponent from './SecondPhantomComponent';
 
 class MyComponent extends Component {}
 
-_setComponentTemplate(MyComponent, {
+_setComponentTemplate({
   id: "UYRxK3x4",
   block: "{\"symbols\":[\"SecondPhantomComponent\"],\"statements\":[[1,1,0,0,\"\\n    \"],[9,\"h1\",true],[10],[1,1,0,0,\"Hello world \\n\"],[5,[27,[26,0,\"BlockHead\"],[]],null,null,[[\"default\"],[{\"statements\":[[1,1,0,0,\"            \"],[7,[27,[24,1],[]],[],[[],[]],null],[1,1,0,0,\"\\n            \"],[1,0,0,0,[27,[24,1],[]]],[1,1,0,0,\"\\n\"]],\"parameters\":[1]}]]],[1,1,0,0,\"        \"],[7,\"SecondPhantomComponent\",[],[[],[]],null],[1,1,0,0,\"\\n    \"],[11]],\"hasEval\":false,\"upvars\":[\"OtherComponent\"]}",
   meta: {
@@ -15,4 +15,4 @@ _setComponentTemplate(MyComponent, {
       SecondPhantomComponent: SecondPhantomComponent
     })
   }
-})
+}, MyComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/nested-classes/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/nested-classes/output.js
@@ -4,7 +4,7 @@ import OtherComponent from './OtherComponent';
 
 class MyComponent extends Component {
   get ChildComponent() {
-    return _setComponentTemplate(class extends Component {}, {
+    return _setComponentTemplate({
       id: "z5SJXwaW",
       block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"Goodbye world\"],[7,\"MyComponent\",[],[[],[]],null],[11]],\"hasEval\":false,\"upvars\":[]}",
       meta: {
@@ -12,12 +12,12 @@ class MyComponent extends Component {
           MyComponent: MyComponent
         })
       }
-    });
+    }, class extends Component {});
   }
 
 }
 
-_setComponentTemplate(MyComponent, {
+_setComponentTemplate({
   id: "O/CNYunf",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[7,\"OtherComponent\",[],[[],[]],null],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
@@ -25,4 +25,4 @@ _setComponentTemplate(MyComponent, {
       OtherComponent: OtherComponent
     })
   }
-})
+}, MyComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/phantom-scope/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/phantom-scope/output.js
@@ -5,7 +5,7 @@ import PhantomComponent from './PhantomComponent';
 
 class MyComponent extends Component {}
 
-_setComponentTemplate(MyComponent, {
+_setComponentTemplate({
   id: "CUkt0JBr",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world \"],[7,\"OtherComponent\",[],[[],[]],null],[1,1,0,0,\" \"],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
@@ -13,4 +13,4 @@ _setComponentTemplate(MyComponent, {
       OtherComponent: OtherComponent
     })
   }
-})
+}, MyComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/precompile-disabled-commonjs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/precompile-disabled-commonjs/output.js
@@ -12,9 +12,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 class MyComponent extends _component.default {}
 
-(0, _core.setComponentTemplate)(MyComponent, (0, _core.createTemplate)({
+(0, _core.setComponentTemplate)((0, _core.createTemplate)({
   OtherComponent: _OtherComponent.default
-}, `<h1>Hello world</h1><OtherComponent/>`))
-const MyComponentExpression = (0, _core.setComponentTemplate)(class extends _component.default {}, (0, _core.createTemplate)({
+}, `<h1>Hello world</h1><OtherComponent/>`), MyComponent)
+const MyComponentExpression = (0, _core.setComponentTemplate)((0, _core.createTemplate)({
   YetAnotherComponent: _YetAnotherComponent.default
-}, `<YetAnotherComponent/>`));
+}, `<YetAnotherComponent/>`), class extends _component.default {});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/precompile-disabled-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/precompile-disabled-hbs/output.js
@@ -4,10 +4,10 @@ import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 import OtherComponent from './OtherComponent';
 import YetAnotherComponent from './YetAnotherComponent';
 
-const template1 = _setComponentTemplate(_templateOnlyComponent(), _createTemplate({
+const template1 = _setComponentTemplate(_createTemplate({
   OtherComponent: OtherComponent
-}, `<h1>Hello world</h1><OtherComponent/>`));
+}, `<h1>Hello world</h1><OtherComponent/>`), _templateOnlyComponent());
 
-const template2 = _setComponentTemplate(_templateOnlyComponent(), _createTemplate({
+const template2 = _setComponentTemplate(_createTemplate({
   YetAnotherComponent: YetAnotherComponent
-}, `<YetAnotherComponent/>`));
+}, `<YetAnotherComponent/>`), _templateOnlyComponent());

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/precompile-disabled/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/precompile-disabled/output.js
@@ -6,10 +6,10 @@ import YetAnotherComponent from './YetAnotherComponent';
 
 class MyComponent extends Component {}
 
-_setComponentTemplate(MyComponent, _createTemplate({
+_setComponentTemplate(_createTemplate({
   OtherComponent: OtherComponent
-}, `<h1>Hello world</h1><OtherComponent/>`))
+}, `<h1>Hello world</h1><OtherComponent/>`), MyComponent)
 
-const MyComponentExpression = _setComponentTemplate(class extends Component {}, _createTemplate({
+const MyComponentExpression = _setComponentTemplate(_createTemplate({
   YetAnotherComponent: YetAnotherComponent
-}, `<YetAnotherComponent/>`));
+}, `<YetAnotherComponent/>`), class extends Component {});

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens-hbs/output.js
@@ -4,7 +4,7 @@ import OtherComponent from './OtherComponent';
 import PhantomComponent from './PhantomComponent';
 import SecondPhantomComponent from './SecondPhantomComponent';
 
-const hbsOnlyTemplate = _setComponentTemplate(_templateOnlyComponent(), {
+const hbsOnlyTemplate = _setComponentTemplate({
   id: "ZciCU0lx",
   block: "{\"symbols\":[\"PhantomComponent\",\"SecondPhantomComponent\"],\"statements\":[[1,1,0,0,\"\\n\"],[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\\n\"],[5,[27,[26,0,\"BlockHead\"],[]],null,null,[[\"default\"],[{\"statements\":[[1,1,0,0,\"        \"],[7,[27,[24,2],[]],[],[[],[]],null],[1,1,0,0,\"\\n        \"],[1,0,0,0,[27,[24,2],[]]],[1,1,0,0,\"\\n\"]],\"parameters\":[2]}]]],[1,1,0,0,\"    \"],[7,\"OtherComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[1,1,0,0,\"\\n        \"],[7,[27,[24,1],[]],[],[[],[]],null],[1,1,0,0,\"\\n        \"],[1,0,0,0,[27,[24,1],[]]],[1,1,0,0,\"\\n    \"]],\"parameters\":[1]}]]],[1,1,0,0,\"\\n\"],[11]],\"hasEval\":false,\"upvars\":[\"OtherComponent\"]}",
   meta: {
@@ -12,4 +12,4 @@ const hbsOnlyTemplate = _setComponentTemplate(_templateOnlyComponent(), {
       OtherComponent: OtherComponent
     })
   }
-});
+}, _templateOnlyComponent());

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens/output.js
@@ -6,7 +6,7 @@ import SecondPhantomComponent from './SecondPhantomComponent';
 
 class MyComponent extends Component {}
 
-_setComponentTemplate(MyComponent, {
+_setComponentTemplate({
   id: "Ao8DUTes",
   block: "{\"symbols\":[\"PhantomComponent\",\"SecondPhantomComponent\"],\"statements\":[[1,1,0,0,\"\\n    \"],[9,\"h1\",true],[10],[1,1,0,0,\"Hello world \\n\"],[5,[27,[26,0,\"BlockHead\"],[]],null,null,[[\"default\"],[{\"statements\":[[1,1,0,0,\"            \"],[7,[27,[24,2],[]],[],[[],[]],null],[1,1,0,0,\"\\n            \"],[1,0,0,0,[27,[24,2],[]]],[1,1,0,0,\"\\n\"]],\"parameters\":[2]}]]],[1,1,0,0,\"        \"],[7,\"OtherComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[1,1,0,0,\"\\n            \"],[7,[27,[24,1],[]],[],[[],[]],null],[1,1,0,0,\" \\n            \"],[1,0,0,0,[27,[24,1],[]]],[1,1,0,0,\"\\n        \"]],\"parameters\":[1]}]]],[1,1,0,0,\"\\n    \"],[11]],\"hasEval\":false,\"upvars\":[\"OtherComponent\"]}",
   meta: {
@@ -14,4 +14,4 @@ _setComponentTemplate(MyComponent, {
       OtherComponent: OtherComponent
     })
   }
-})
+}, MyComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs-with-component-import/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs-with-component-import/output.js
@@ -2,13 +2,13 @@ import { templateOnlyComponent as _templateOnlyComponent } from "@glimmer/core";
 import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 import { renderComponent } from '@glimmer/core';
 import IamGlimmerComponent from '@glimmerx/component';
-renderComponent(_setComponentTemplate(_templateOnlyComponent(), {
+renderComponent(_setComponentTemplate({
   id: "wr1/fM82",
   block: "{\"symbols\":[\"@name\"],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello \"],[1,0,0,0,[27,[24,1],[]]],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-}), {
+}, _templateOnlyComponent()), {
   args: {
     name: 'Abhishek'
   },

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs/output.js
@@ -1,13 +1,13 @@
 import { templateOnlyComponent as _templateOnlyComponent } from "@glimmer/core";
 import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 import { renderComponent } from '@glimmer/core';
-renderComponent(_setComponentTemplate(_templateOnlyComponent(), {
+renderComponent(_setComponentTemplate({
   id: "wr1/fM82",
   block: "{\"symbols\":[\"@name\"],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello \"],[1,0,0,0,[27,[24,1],[]]],[11]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
-}), {
+}, _templateOnlyComponent()), {
   args: {
     name: 'Abhishek'
   },

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/typescript/output.ts
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/typescript/output.ts
@@ -8,7 +8,7 @@ export function foo() {
 }
 export class MyComponent extends Component {}
 
-_setComponentTemplate(MyComponent, {
+_setComponentTemplate({
   id: "hNaOsjkR",
   block: "{\"symbols\":[],\"statements\":[[9,\"h1\",false],[3,0,0,[27,[26,0,\"ModifierHead\"],[]],null,null],[10],[1,1,0,0,\"Hello world \"],[1,0,0,0,[27,[26,1,\"AppendSingleId\"],[]]],[7,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[7,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[11]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
   meta: {
@@ -18,4 +18,4 @@ _setComponentTemplate(MyComponent, {
       maybeModifier: maybeModifier
     })
   }
-});
+}, MyComponent);

--- a/packages/@glimmerx/component/package.json
+++ b/packages/@glimmerx/component/package.json
@@ -12,8 +12,8 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/component": "^2.0.0-beta.3",
-    "@glimmer/tracking": "^2.0.0-beta.3"
+    "@glimmer/component": "^2.0.0-beta.5",
+    "@glimmer/tracking": "^2.0.0-beta.5"
   },
   "volta": {
     "node": "12.10.0",

--- a/packages/@glimmerx/core/package.json
+++ b/packages/@glimmerx/core/package.json
@@ -12,7 +12,7 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/core": "^2.0.0-beta.3",
+    "@glimmer/core": "^2.0.0-beta.5",
     "@glimmer/interfaces": "^0.50.0"
   },
   "volta": {

--- a/packages/@glimmerx/helper/package.json
+++ b/packages/@glimmerx/helper/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@glimmerx/core": "0.1.10",
-    "@glimmer/helper": "^2.0.0-beta.3",
+    "@glimmer/helper": "^2.0.0-beta.5",
     "@glimmer/interfaces": "^0.50.0"
   },
   "volta": {

--- a/packages/@glimmerx/modifier/package.json
+++ b/packages/@glimmerx/modifier/package.json
@@ -12,8 +12,8 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/core": "^2.0.0-beta.3",
-    "@glimmer/modifier": "^2.0.0-beta.3"
+    "@glimmer/core": "^2.0.0-beta.5",
+    "@glimmer/modifier": "^2.0.0-beta.5"
   },
   "volta": {
     "node": "12.10.0",

--- a/packages/@glimmerx/ssr/package.json
+++ b/packages/@glimmerx/ssr/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@glimmer/interfaces": "^0.50.0",
-    "@glimmer/ssr": "^2.0.0-beta.3",
+    "@glimmer/ssr": "^2.0.0-beta.5",
     "@glimmerx/core": "^0.1.10"
   },
   "volta": {

--- a/packages/@glimmerx/storybook/package.json
+++ b/packages/@glimmerx/storybook/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.7.0",
     "@babel/plugin-proposal-decorators": "^7.7.0",
-    "@glimmer/babel-plugin-strict-template-precompile": "^2.0.0-beta.3",
+    "@glimmer/babel-plugin-strict-template-precompile": "^2.0.0-beta.5",
     "@glimmerx/babel-plugin-component-templates": "^0.1.9",
     "@glimmerx/component": "^0.1.0",
     "@glimmerx/core": "^0.1.0",


### PR DESCRIPTION
There was a mismatch in the previous beta with the
`setComponentTemplate` API, Ember's puts the template first instead of
second. The latest API fixes this, and this PR updates to the latest
beta and fixes the transform.