### PR TITLE
[BUGFIX] Fix Playground asset urls

### DIFF
--- a/packages/examples/playground/testem.json
+++ b/packages/examples/playground/testem.json
@@ -5,7 +5,7 @@
     "/": "dist"
   },
   "on_start": {
-    "command": "webpack",
+    "command": "TESTEM=true webpack",
     "wait_for_text": "Built at:",
     "wait_for_text_timeout": 300000
   },

--- a/packages/examples/playground/webpack.config.js
+++ b/packages/examples/playground/webpack.config.js
@@ -65,7 +65,7 @@ module.exports = () => {
     output: {
       filename: '[name].bundle.js',
       path: path.resolve(__dirname, 'dist'),
-      publicPath: '/',
+      publicPath: process.env.TESTEM ? '/' : '',
     },
     devServer: {
       contentBase: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
Testem prefers assets to have absolute paths, but this doesn't work with
GH-pages. We should try to figure out a better solution here in the
future, but this should work for now.