### PR TITLE
[CHORE] Bump to glimmerjs 2.0.0-beta.7 which contains glimmer-vm 0.51.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-typescript": "^7.9.0",
-    "@glimmer/babel-plugin-glimmer-env": "2.0.0-beta.6",
+    "@glimmer/babel-plugin-glimmer-env": "2.0.0-beta.7",
     "@types/qunit": "^2.9.1",
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",

--- a/packages/@glimmerx/babel-plugin-component-templates/package.json
+++ b/packages/@glimmerx/babel-plugin-component-templates/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@babel/core": "^7.9.0",
     "@babel/helper-module-imports": "^7.8.3",
-    "@glimmer/babel-plugin-strict-template-precompile": "2.0.0-beta.6",
+    "@glimmer/babel-plugin-strict-template-precompile": "2.0.0-beta.7",
     "@glimmer/syntax": "^0.50.1"
   },
   "devDependencies": {

--- a/packages/@glimmerx/blueprint/files/package.json
+++ b/packages/@glimmerx/blueprint/files/package.json
@@ -20,7 +20,7 @@
     "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-typescript": "^7.9.0",
-    "@glimmer/babel-plugin-glimmer-env": "~2.0.0-beta.6",
+    "@glimmer/babel-plugin-glimmer-env": "~2.0.0-beta.7",
     "@glimmer/env": "^0.1.7",
     "@glimmerx/babel-plugin-component-templates": "^0.1.0",
     "@glimmerx/component": "^0.1.0",

--- a/packages/@glimmerx/blueprint/package.json
+++ b/packages/@glimmerx/blueprint/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/glimmerjs/glimmer-experimental#readme",
   "dependencies": {
-    "@glimmer/blueprint": "2.0.0-beta.6",
+    "@glimmer/blueprint": "2.0.0-beta.7",
     "ember-cli-string-utils": "^1.1.0",
     "walk-sync": "^2.0.2"
   },

--- a/packages/@glimmerx/component/package.json
+++ b/packages/@glimmerx/component/package.json
@@ -15,8 +15,8 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/component": "2.0.0-beta.6",
-    "@glimmer/tracking": "2.0.0-beta.6",
+    "@glimmer/component": "2.0.0-beta.7",
+    "@glimmer/tracking": "2.0.0-beta.7",
     "@glimmerx/babel-plugin-component-templates": "^0.2.1",
     "ember-cli-babel": "^7.17.2",
     "ember-cli-babel-plugin-helpers": "^1.1.0"

--- a/packages/@glimmerx/core/package.json
+++ b/packages/@glimmerx/core/package.json
@@ -17,7 +17,7 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/core": "2.0.0-beta.6",
+    "@glimmer/core": "2.0.0-beta.7",
     "@glimmer/interfaces": "^0.50.1"
   },
   "volta": {

--- a/packages/@glimmerx/helper/package.json
+++ b/packages/@glimmerx/helper/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@glimmerx/core": "0.2.1",
-    "@glimmer/helper": "2.0.0-beta.6",
+    "@glimmer/helper": "2.0.0-beta.7",
     "@glimmer/interfaces": "^0.50.1",
     "ember-cli-babel": "^7.18.0"
   },

--- a/packages/@glimmerx/modifier/package.json
+++ b/packages/@glimmerx/modifier/package.json
@@ -20,8 +20,8 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/core": "2.0.0-beta.6",
-    "@glimmer/modifier": "2.0.0-beta.6",
+    "@glimmer/core": "2.0.0-beta.7",
+    "@glimmer/modifier": "2.0.0-beta.7",
     "ember-cli-babel": "^7.18.0"
   },
   "volta": {

--- a/packages/@glimmerx/ssr/package.json
+++ b/packages/@glimmerx/ssr/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@glimmer/interfaces": "^0.50.1",
-    "@glimmer/ssr": "2.0.0-beta.6",
+    "@glimmer/ssr": "2.0.0-beta.7",
     "@glimmerx/core": "^0.2.1"
   },
   "volta": {

--- a/packages/@glimmerx/storybook/package.json
+++ b/packages/@glimmerx/storybook/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-decorators": "^7.8.3",
-    "@glimmer/babel-plugin-strict-template-precompile": "2.0.0-beta.6",
+    "@glimmer/babel-plugin-strict-template-precompile": "2.0.0-beta.7",
     "@glimmerx/babel-plugin-component-templates": "^0.2.1",
     "@glimmerx/component": "^0.2.1",
     "@glimmerx/core": "^0.2.1",

--- a/packages/examples/basic-addon/package.json
+++ b/packages/examples/basic-addon/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
-    "@glimmer/tracking": "2.0.0-beta.6",
+    "@glimmer/tracking": "2.0.0-beta.7",
     "@glimmerx/eslint-plugin": "^0.2.1",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/examples/ember-app/package.json
+++ b/packages/examples/ember-app/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
     "@glimmer/component": "^1.0.0",
-    "@glimmer/tracking": "2.0.0-beta.6",
+    "@glimmer/tracking": "2.0.0-beta.7",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.5.3",

--- a/packages/examples/playground/package.json
+++ b/packages/examples/playground/package.json
@@ -20,7 +20,7 @@
     "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-typescript": "^7.9.0",
-    "@glimmer/babel-plugin-glimmer-env": "~2.0.0-beta.6",
+    "@glimmer/babel-plugin-glimmer-env": "~2.0.0-beta.7",
     "@glimmer/env": "^0.1.7",
     "@glimmerx/babel-plugin-component-templates": "^0.2.1",
     "@glimmerx/component": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1273,52 +1273,52 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@glimmer/babel-plugin-glimmer-env@2.0.0-beta.6", "@glimmer/babel-plugin-glimmer-env@~2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@glimmer/babel-plugin-glimmer-env/-/babel-plugin-glimmer-env-2.0.0-beta.6.tgz#ee5c9423c5f4750b63221b49bd25471b5b944350"
-  integrity sha512-SySkorE0wZhleGQYYsBuKLx79ZGyZ+rKhOt9nbaCZyjPGcx0l4du678Mj0Q+nLkWxIX22zZD+5mkE8g85ujDVQ==
+"@glimmer/babel-plugin-glimmer-env@2.0.0-beta.7", "@glimmer/babel-plugin-glimmer-env@~2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/babel-plugin-glimmer-env/-/babel-plugin-glimmer-env-2.0.0-beta.7.tgz#d26613a38bc343cdbf2023bffb0d08f933e799dd"
+  integrity sha512-TBDJzaUKbtnfJpBymGVbqD/qAepMp7TNYBDqsbz9zs+GD/vDk2JCPKsWmv9CsHu7zYe1drufMFL6HfF+W8bB2w==
   dependencies:
     "@babel/core" "^7.5.5"
     babel-plugin-debug-macros "^0.3.3"
 
-"@glimmer/babel-plugin-strict-template-precompile@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@glimmer/babel-plugin-strict-template-precompile/-/babel-plugin-strict-template-precompile-2.0.0-beta.6.tgz#546d444c4e53272357931e288aab86e8bb4778f7"
-  integrity sha512-0oP49Zz2QOu7Y8sQhTr5/uktgL3oBUleGKR2FtuD3itgWkoloQEUlODS/kvyoUD4knf5B4gkz1KsmCBE3v/gzQ==
+"@glimmer/babel-plugin-strict-template-precompile@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/babel-plugin-strict-template-precompile/-/babel-plugin-strict-template-precompile-2.0.0-beta.7.tgz#d2d21e25b0dc7946f7aec610170ead6921e9563d"
+  integrity sha512-6A7tpxGDTLibBkn5+ddiBn4OaTIDV6Fv8Zi/P7wv4xkgzpSsHoZmSV4ytSMdwypF/KrR0iAAwQ8koIstGNXM+w==
   dependencies:
     "@babel/core" "^7.5.5"
     "@babel/generator" "^7.9.4"
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/parser" "^7.9.4"
     "@babel/types" "^7.9.0"
-    "@glimmer/compiler" "0.50.0"
+    "@glimmer/compiler" "0.51.0"
 
-"@glimmer/blueprint@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@glimmer/blueprint/-/blueprint-2.0.0-beta.6.tgz#6552714afbb63c63663fec9f1028e4a227d1ba86"
-  integrity sha512-5dcTZKpZYQjSR0HYJVT61lPfTFZ4MkjTPl+Ol58JbdkHyGFeKBQnMDX/jfTcv0vi9EKRw0Hu4hpv1lCrK0EjCA==
+"@glimmer/blueprint@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/blueprint/-/blueprint-2.0.0-beta.7.tgz#b8d511a78174985a95337df033c5dfbca15f7093"
+  integrity sha512-6U1mg6t10zVRkedLHvStEJZHImjn7F1oqwvGQ9E+XwV1BP4WJMRJt7SCj3TeiqLp+rRC70dXA9irtMh3m8wWTA==
   dependencies:
     ember-cli-string-utils "^1.1.0"
 
-"@glimmer/compiler@0.50.0":
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.50.0.tgz#ace8e05fa1b768b73571ad945dbbfab4178793de"
-  integrity sha512-jhruI6Y2hmchiPE0olCRhTY5HMZVe1Mm3V2tZh8Vatq1s74/uvUu8XaaK87Ij3eBNFVTAa7KhrTtkuEA85J5nw==
+"@glimmer/compiler@0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.51.0.tgz#35b287db3da96b8de9ab1efafa49ab041c68398e"
+  integrity sha512-TXQw4AyNJOpHcOlO5h1U3Yf5X9aAfeiC5VJavsNXsNtzx22/RfSalsMXPjc6R4IzLP9ihjlMEK/uG8MncsOUyg==
   dependencies:
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/syntax" "^0.50.0"
-    "@glimmer/util" "^0.50.0"
-    "@glimmer/wire-format" "^0.50.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/syntax" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
+    "@glimmer/wire-format" "^0.51.0"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/component@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-2.0.0-beta.6.tgz#2dbf98740d97b6497dad0a613ab7cc42ea524f64"
-  integrity sha512-XwVfJ5SChNifDs72v9XUZHVZa9kqAPAxqyqMXPogidDMzqHEc/ZoS5SlG0ZRwQMscDJTeAMei8tpMSrzEriLHQ==
+"@glimmer/component@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-2.0.0-beta.7.tgz#7f73c0ac5699d8aa0213af2408a7ed86363a8515"
+  integrity sha512-LDSb2/+0AqVQShG6jan/N7RI5698bkY3QHPv+tH2n3BlE2Hr/ZRJP23dJmaP+AJ7sp/kH+v/SmTfqgGeMXELYA==
   dependencies:
-    "@glimmer/core" "2.0.0-beta.6"
+    "@glimmer/core" "2.0.0-beta.7"
     "@glimmer/env" "^0.1.7"
-    "@glimmer/util" "^0.50.0"
+    "@glimmer/util" "^0.51.0"
     broccoli-file-creator "^2.1.1"
     broccoli-merge-trees "^3.0.2"
     ember-cli-babel "^7.7.3"
@@ -1349,16 +1349,16 @@
     ember-cli-typescript "3.0.0"
     ember-compatibility-helpers "^1.1.2"
 
-"@glimmer/core@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@glimmer/core/-/core-2.0.0-beta.6.tgz#d9156983a213b83c87163d0c5a0ea77f354d8a97"
-  integrity sha512-4RR/bh7jbLguctBBEWZmfVeJkpk45x8lx3u0heoJUt7YMMKbaLaewq6Yt4W+haEh/xxsQnxj/C/zdKtJSnbjBQ==
+"@glimmer/core@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/core/-/core-2.0.0-beta.7.tgz#f7d8d8b2bc6dba9fe077b67046e825b068fda8db"
+  integrity sha512-5hdXekJ5UTMqm/EcRe/1x19ncpHGUcG1+nX7CwuHpHyR36YEjxEAyIEfh0ZJJPuP8pCmJ+osTjMa6ztKFCv17g==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/opcode-compiler" "^0.50.0"
-    "@glimmer/runtime" "^0.50.0"
-    "@glimmer/validator" "^0.50.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/opcode-compiler" "^0.51.0"
+    "@glimmer/runtime" "^0.51.0"
+    "@glimmer/validator" "^0.51.0"
     "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/di@^0.1.9":
@@ -1366,118 +1366,125 @@
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.1.11.tgz#a6878c07a13a2c2c76fcde598a5c97637bfc4280"
   integrity sha1-poeMB6E6LCx2/N5ZilyXY3v8QoA=
 
-"@glimmer/encoder@^0.50.1":
-  version "0.50.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.50.1.tgz#093e12059214c444ac65e054ad1b6f484958df5e"
-  integrity sha512-41u2qcJlCx2qox9qYSP7gZDRe114exxx1uzb3U0JY6e4lxxSOHLB98icqY5XcNkfmFedCWRP7y1JWegaCTkIOQ==
+"@glimmer/encoder@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.51.0.tgz#a8c7dfd760964ecd53d7def550a66e3e9564ba62"
+  integrity sha512-EakrjpISwKf7NQlbo+beq8mxt3njcLt1ciqs51NL8pMDachaCtY57wTUSVXN9URb230dyGxU0VbWMKBeqvjTOA==
   dependencies:
-    "@glimmer/interfaces" "^0.50.1"
-    "@glimmer/vm" "^0.50.1"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/vm" "^0.51.0"
 
 "@glimmer/env@0.1.7", "@glimmer/env@^0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
 
-"@glimmer/helper@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@glimmer/helper/-/helper-2.0.0-beta.6.tgz#2516c8b9545b6ed6ac7affffa2f85f18b641808f"
-  integrity sha512-i7f692BHanJZ0YUOuECz6tP3423N+TCIJJmol2+bGrEpLQzCLziFdzQITbSgrE4+LLZcTG4VEATUGo/3aGOdhQ==
+"@glimmer/helper@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/helper/-/helper-2.0.0-beta.7.tgz#c213fdb7dea89343e2039b3d55bda98a55275272"
+  integrity sha512-6d8toFGuN01YA+Izk/m5xkUKdWAieDXOgZYSogamjGfMmFmUJY+VbGTh1Cu5hKA9fdOpccF0lQDqWu5TPWwA+Q==
   dependencies:
-    "@glimmer/component" "2.0.0-beta.6"
-    "@glimmer/core" "2.0.0-beta.6"
-    "@glimmer/interfaces" "^0.50.0"
-    "@glimmer/reference" "^0.50.0"
+    "@glimmer/component" "2.0.0-beta.7"
+    "@glimmer/core" "2.0.0-beta.7"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/reference" "^0.51.0"
 
-"@glimmer/interfaces@^0.50.0", "@glimmer/interfaces@^0.50.1":
+"@glimmer/interfaces@^0.50.1":
   version "0.50.1"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.50.1.tgz#008620d9b42e296ce89669415e4830354b83c4fb"
   integrity sha512-ye9fWev8QxK8Y8+NzCa0uJDArFURbVhAahSFyPT25UdalYCWEmJmqD7k1KezZk2N7ZPxLPaBjOk9ifzDPRGHgg==
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/low-level@^0.50.1":
-  version "0.50.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.50.1.tgz#8c63355da7b5452ee14bbb4d7f9bb868a91d48e8"
-  integrity sha512-rTMCqTGmV7JRVFrWa1ff2tkr+oQ/kfUcxJBpynCm5n7JtFH31R+WJFDrxrDoGfJ63qKuhnli47jwB08vYl0fCg==
-
-"@glimmer/modifier@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@glimmer/modifier/-/modifier-2.0.0-beta.6.tgz#f956acaed386eefe7e8914b3098bc81ad03716cb"
-  integrity sha512-N5rQ6B/H5UzGhJhMhDHtWuF3scTEp3Nb5ePLLviA41Spjmy1fq4GIT5sQZPkBomzwmAZxvXDNxag19BtpC45Jw==
+"@glimmer/interfaces@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.51.0.tgz#a25ee61a302bcb8ee45b4b9f7e825a8af5874b49"
+  integrity sha512-QouZvCRnIpeRFAgEsk5T7FXVQ7xzUNRMDPfEfNXoTPlEYkbC2J9BngaTo0U2Un6OGHt/du8DqEw7gXurBe9SNQ==
   dependencies:
-    "@glimmer/interfaces" "^0.50.0"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/node@^0.50.0":
-  version "0.50.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.50.1.tgz#9c44c8ca22af5ba33353540ea01d8ae529287e1d"
-  integrity sha512-uYrRO3+O8V/1hyMjAiRV88OA09k91pCJLQz7IG2BYo2mxQBI8h2Z2ENFhCBAqw4nEuUSQnDF3s72G0Qmfp84og==
+"@glimmer/low-level@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.51.0.tgz#04c3caf774a9ef458dbd9b07f4955b09873ea27a"
+  integrity sha512-pZit5wGMn8M8Tl/aoeRgNR5v16vr0Q+dsx+2/itA0I+1LubBSqDfZUa3ye2Ut1nwjKY8qzwH7T6gr/ef9taeeQ==
+
+"@glimmer/modifier@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/modifier/-/modifier-2.0.0-beta.7.tgz#8cdc7bcfbfc3c902196edd7731159218aaf275cb"
+  integrity sha512-GXpPObr/Dsj71xzN7QKZXYHeWX101j+q0sJwrQH3JkrXVaGohJVTFfRjWsxg1D3Ats/j27QG6Fxu7v/VrdO94w==
   dependencies:
-    "@glimmer/interfaces" "^0.50.1"
-    "@glimmer/runtime" "^0.50.1"
-    "@glimmer/util" "^0.50.1"
+    "@glimmer/interfaces" "^0.51.0"
+    "@simple-dom/interface" "^1.4.0"
+
+"@glimmer/node@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.51.0.tgz#d945c270f2a78ce7767e5e011dbffd8092a6a79c"
+  integrity sha512-G9x7qtpRFPyju17fPMTrP3KRqeKJmlW81seXQM34enKMoB6q84jjLcT3VzpdH7rmqJkfUM7zCqRFTjzP8TixEw==
+  dependencies:
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/runtime" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
     "@simple-dom/document" "^1.4.0"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/opcode-compiler@^0.50.0":
-  version "0.50.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.50.1.tgz#05d7770506cc60ef74b3de85058fbedf82a61e9d"
-  integrity sha512-s503N/d3n7SfH+iJQIYnOlLd6trrrsdbf8kUWGeRcukOUkkykiBrKHvGI7sGBYJ1GAEhLwLJ0T1rIWJAkF+oSg==
+"@glimmer/opcode-compiler@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.51.0.tgz#30d537648262c95e06f26a46df82209d3958fcc7"
+  integrity sha512-hE2bGKkmga5AfkeAV806UppL/w2/wylDTMfBOu71/ZORYvDdFDCGvzL+bE8yy44e+LteIJhOPvRD7+YvNkRstQ==
   dependencies:
-    "@glimmer/encoder" "^0.50.1"
-    "@glimmer/interfaces" "^0.50.1"
-    "@glimmer/program" "^0.50.1"
-    "@glimmer/reference" "^0.50.1"
-    "@glimmer/util" "^0.50.1"
-    "@glimmer/vm" "^0.50.1"
-    "@glimmer/wire-format" "^0.50.1"
+    "@glimmer/encoder" "^0.51.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/program" "^0.51.0"
+    "@glimmer/reference" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
+    "@glimmer/vm" "^0.51.0"
+    "@glimmer/wire-format" "^0.51.0"
 
-"@glimmer/program@^0.50.1":
-  version "0.50.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.50.1.tgz#76cdcfcd79da0f44b583b78be3145ea5d2f45b4f"
-  integrity sha512-kNXAA3A9IimnLVo0cFINxW11vahW8wc4vG61Kbs4k2TAVo6MXxW1XbXeYhv5oHnMnO57m2R3KvqFBkpCF9EUxw==
+"@glimmer/program@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.51.0.tgz#02af329dec6241d806ee1962f7aa8d17b6a114c0"
+  integrity sha512-KBZmVSb8wacoB3PwF72xsJV+F+tdXBklS6qqF0GMdJEWJhp53z2jTElSDnODNY2Rf+lnq9u3GrrfZMQmGjkgbw==
   dependencies:
-    "@glimmer/encoder" "^0.50.1"
-    "@glimmer/interfaces" "^0.50.1"
-    "@glimmer/util" "^0.50.1"
+    "@glimmer/encoder" "^0.51.0"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
 
-"@glimmer/reference@^0.50.0", "@glimmer/reference@^0.50.1":
-  version "0.50.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.50.1.tgz#8971f71d90ef109b55d1e047e6a6bcc16fe9433b"
-  integrity sha512-u0RIwdvDu3l9LlnQskhC9OBgHGTSp2E/sNsiZsiRrqWwhm7ElF6XVtckbyPh+XleSSo9I8iAIrB4fNvoGw6gHw==
+"@glimmer/reference@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.51.0.tgz#1d25e088dc91af7884bc4a881202b3ee0cabb094"
+  integrity sha512-tnWa93CRj1O61IoCKgdJh910rgPy1UmV1zAykcSVd26YKS6oqnh6lLMww+apToCJB3llLbp71qzjZVR35eb7Mg==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/interfaces" "^0.50.1"
-    "@glimmer/util" "^0.50.1"
-    "@glimmer/validator" "^0.50.1"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
+    "@glimmer/validator" "^0.51.0"
 
-"@glimmer/runtime@^0.50.0", "@glimmer/runtime@^0.50.1":
-  version "0.50.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.50.1.tgz#e473b6f88684f0c91cbc4cef96d7d8543e719ba6"
-  integrity sha512-h43cSgwlLt+fPIIaaSHsXeppP7mqactz5AfsaCblgYYgTOL/V74iIMpTVvJNAeBjhSyB9TWYZh1iu0bpZA/8Lg==
+"@glimmer/runtime@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.51.0.tgz#fbde6e563e5532f050ebee6ed2b1f21506c66f80"
+  integrity sha512-RwpaI6K8FGMA39Hw1dzjuXbOuoCsYavW1tZChEO23wZuO2QawggpGXDV9R5czqDYr0k6a2mKs8nZNgTIsf61Yg==
   dependencies:
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "^0.50.1"
-    "@glimmer/low-level" "^0.50.1"
-    "@glimmer/program" "^0.50.1"
-    "@glimmer/reference" "^0.50.1"
-    "@glimmer/util" "^0.50.1"
-    "@glimmer/validator" "^0.50.1"
-    "@glimmer/vm" "^0.50.1"
-    "@glimmer/wire-format" "^0.50.1"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/low-level" "^0.51.0"
+    "@glimmer/program" "^0.51.0"
+    "@glimmer/reference" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
+    "@glimmer/validator" "^0.51.0"
+    "@glimmer/vm" "^0.51.0"
+    "@glimmer/wire-format" "^0.51.0"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/ssr@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@glimmer/ssr/-/ssr-2.0.0-beta.6.tgz#b13deebe74bc555b1533f6aeccc16620d205470a"
-  integrity sha512-2DPKZee/TvBGaPESSF42d249NJhXMZVI9VdcdxnIX9NKhv8bD/OHvhc1+ixjuduz+uDOzD0jcqeel1fPyThshA==
+"@glimmer/ssr@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/ssr/-/ssr-2.0.0-beta.7.tgz#ed96ae5da177fe0ef7b13ea6e15bc12c90bd5d35"
+  integrity sha512-UxfnJAZK8FRTpHSu1ah8FnVTaimPJQtAsFKkhWXEZo+V0ElhSCV+PmXWfPwrRotdNTdaeZowJNbg2dliyBiCNw==
   dependencies:
-    "@glimmer/core" "2.0.0-beta.6"
-    "@glimmer/node" "^0.50.0"
-    "@glimmer/reference" "^0.50.0"
-    "@glimmer/runtime" "^0.50.0"
-    "@glimmer/util" "^0.50.0"
+    "@glimmer/core" "2.0.0-beta.7"
+    "@glimmer/node" "^0.51.0"
+    "@glimmer/reference" "^0.51.0"
+    "@glimmer/runtime" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
     "@simple-dom/document" "^1.4.0"
     "@simple-dom/serializer" "^1.4.0"
     "@simple-dom/void-map" "^1.4.0"
@@ -1492,20 +1499,30 @@
     handlebars "^4.5.1"
     simple-html-tokenizer "^0.5.9"
 
-"@glimmer/tracking@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-2.0.0-beta.6.tgz#8220620785d2fb8b01bc24e4718ec99401be972e"
-  integrity sha512-HBfSRrFlpbJgab4vLKBK+b+RvwEuAoS3Fz4Bi9UZqrRvlB38mfqfyj9qncJIB4OMccHwy9FqMXkQ10IIi0OBYA==
+"@glimmer/syntax@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.51.0.tgz#f9d258e9a763e91b751a7dbdb51c0a338da54ba8"
+  integrity sha512-gRmlZBrlAwPj53ZO69SbPi8JXQBrGqheB1OvWtJilTmUKz5nPVt8J5E8ttvS7yotRWrht/jO7qOr3s4GlWp5pA==
+  dependencies:
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
+    handlebars "^4.7.4"
+    simple-html-tokenizer "^0.5.9"
+
+"@glimmer/tracking@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-2.0.0-beta.7.tgz#ac27e2ad4d6530a4fb3bff37eb9b71528def6ce9"
+  integrity sha512-YmYUSypcJmL43jgcOC0bgMaGTnZmRwzxQ1DY66sl1agLKkk4xO98/U8lMLsoD5VbhIJHTZELQPTXm1wYnJxcew==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/validator" "^0.50.0"
+    "@glimmer/validator" "^0.51.0"
 
 "@glimmer/util@^0.44.0":
   version "0.44.0"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.44.0.tgz#45df98d73812440206ae7bda87cfe04aaae21ed9"
   integrity sha512-duAsm30uVK9jSysElCbLyU6QQYO2X9iLDLBIBUcCqck9qN1o3tK2qWiHbGK5d6g8E2AJ4H88UrfElkyaJlGrwg==
 
-"@glimmer/util@^0.50.0", "@glimmer/util@^0.50.1":
+"@glimmer/util@^0.50.1":
   version "0.50.1"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.50.1.tgz#9e85e005d2fd563f979c5fba99563bfe75edf2a9"
   integrity sha512-LaoSboa+BXjunun8wwVEV+FOH5oHc8AckfsmyHsHltFTwIRpjb0w0AQzeHzHXHMVhfpYHB06xlFO9naSEztB1Q==
@@ -1514,28 +1531,37 @@
     "@glimmer/interfaces" "^0.50.1"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/validator@^0.50.0", "@glimmer/validator@^0.50.1":
-  version "0.50.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.50.1.tgz#3dd7ce7c945caed25d9c6d465ab3697be15a8144"
-  integrity sha512-mFPm+8cgIFjNznSvEGRcJbveZQYW7E9eiKFtUQW2VJdzTUxoal9ds+irR8tzEkUDio/cubQ7BJhV40vLpebOSw==
+"@glimmer/util@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.51.0.tgz#cb664724608a88bb6c249e34284e54c8ac428831"
+  integrity sha512-FnD+GTD2QsG9YShTBY4GSTd8lAtheXTjJxuZW0OF4Mzeb77kW49lrM0vFh/6OciOqfwQf4rp+7EU0KDFqpGFtg==
+  dependencies:
+    "@glimmer/env" "0.1.7"
+    "@glimmer/interfaces" "^0.51.0"
+    "@simple-dom/interface" "^1.4.0"
+
+"@glimmer/validator@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.51.0.tgz#3c4074bf7fb774e373caf17d8187afaf367d17e9"
+  integrity sha512-bH7o0FBaYWx7gcKC/5oEL3asQYYDx31N5WNFl9qZ3PjlyPYq73qqwvEbAYbwcByI55a176fnh+mQoUZsDkYGeA==
   dependencies:
     "@glimmer/env" "^0.1.7"
 
-"@glimmer/vm@^0.50.1":
-  version "0.50.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.50.1.tgz#8d4a815ccb9e0b2f24cb270b374621ec06b11b9d"
-  integrity sha512-9uEZzJIr/yGlK080+WkpxqDF5F262BRBg79kczN1VNi6ThJBRiVgBVzKBh0kNFjIPuiE55tskf2YXS5dKYGqYA==
+"@glimmer/vm@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.51.0.tgz#0e6086ee7801730da1a9c4fb3542a8c94795898f"
+  integrity sha512-s7hbl359mmjVBt9lFAaCHvwnFvJ6T7z+0eh6kjhWmHDCJ7cSzMIcjA/B3psMwzojrEj+xFUHPWZJ2px+8NuQXA==
   dependencies:
-    "@glimmer/interfaces" "^0.50.1"
-    "@glimmer/util" "^0.50.1"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
 
-"@glimmer/wire-format@^0.50.0", "@glimmer/wire-format@^0.50.1":
-  version "0.50.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.50.1.tgz#826f34b222753c810b7e3f5c0d07fba2c704aa83"
-  integrity sha512-aYtcl5wAtG6n36qFxAnmWXAAFfZtN0fSCeU6t0+ExzHnBDpkWs2hM23/5LkF9VhaPNhwZ8wBjPFLEkdggYHW7g==
+"@glimmer/wire-format@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.51.0.tgz#34264470fce4e109120e2304a45f0eac2c8b4c2e"
+  integrity sha512-OrxNVw41ZKsw32cafR+mlVg8e552sx4NT4Ctg/0aqBv0jfON14eqjM+z3JznHnUbz8HdsrVvH9IdVu2rIP8IVA==
   dependencies:
-    "@glimmer/interfaces" "^0.50.1"
-    "@glimmer/util" "^0.50.1"
+    "@glimmer/interfaces" "^0.51.0"
+    "@glimmer/util" "^0.51.0"
 
 "@iarna/toml@2.2.3":
   version "2.2.3"
@@ -10222,7 +10248,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
-handlebars@^4.0.11, handlebars@^4.0.4, handlebars@^4.3.1, handlebars@^4.4.0, handlebars@^4.5.1, handlebars@^4.7.3:
+handlebars@^4.0.11, handlebars@^4.0.4, handlebars@^4.3.1, handlebars@^4.4.0, handlebars@^4.5.1, handlebars@^4.7.3, handlebars@^4.7.4:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
   integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==


### PR DESCRIPTION
Use latest glimmer-vm which swaps the main entry point for node to es2017.