### PR TITLE
Add hook for release-it to run build before releasing

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
     "registry": "https://registry.npmjs.org"
   },
   "release-it": {
+    "hooks": {
+      "after:bump": "yarn build"
+    },
     "plugins": {
       "release-it-lerna-changelog": {
         "infile": "CHANGELOG.md",


### PR DESCRIPTION
**Why**
Currently we need to manually run build before running release-it otherwise the package is malformed.