### PR TITLE
Update ESLint plugin to handle Handlebar's native #with token

### DIFF
--- a/packages/@glimmerx/eslint-plugin/lib/rules/template-vars.js
+++ b/packages/@glimmerx/eslint-plugin/lib/rules/template-vars.js
@@ -21,7 +21,7 @@ module.exports = {
       {
         type: 'object',
         properties: {
-          // ['if', 'each', 'unless', 'has-block', 'yield'] will always be 'nativeTokens'
+          // ['if', 'each', 'unless', 'has-block', 'yield', 'component, 'with'] will always be 'nativeTokens'
           // but you may add more via this configuration. One use-case is if a token is added to the
           // Javascript code implicitly (such as via a babel transform)
           nativeTokens: {
@@ -36,7 +36,7 @@ module.exports = {
     ],
   },
   create(context) {
-    const defaultNativeTokens = ['if', 'each', 'unless', 'has-block', 'yield', 'component'];
+    const defaultNativeTokens = ['if', 'each', 'unless', 'has-block', 'yield', 'component', 'with'];
     let isGlimmerSfc = false;
     let hbsImportId;
 

--- a/packages/@glimmerx/eslint-plugin/test/lib/rules/template-vars.js
+++ b/packages/@glimmerx/eslint-plugin/test/lib/rules/template-vars.js
@@ -192,7 +192,10 @@ ruleTester.run('template-vars', rule, {
               If check should not cause a failure
             {{/if}}
             {{#each @items key="@index" as |item| }}
-              Neither Should each
+              Neither should each
+              {{#with item.name as |name|}}
+                Neither should with
+              {{/with}}
             {{/each}}
           \`;
           method() {


### PR DESCRIPTION
Currently, when developers try to use the native "with" helper (https://handlebarsjs.com/guide/builtin-helpers.html#with), the Glimmer ESLint plugin throws the error "Token with is used in an hbs tagged template literal, but is not defined  @glimmerx/template-vars". This change adds support for Handlebar's "with" helper.