### PR TITLE
Adding support for rehydration and some example apps 

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-typescript": "^7.9.0",
-    "@glimmer/babel-plugin-glimmer-env": "2.0.0-beta.7",
+    "@glimmer/babel-plugin-glimmer-env": "2.0.0-beta.11",
     "@types/qunit": "^2.9.1",
     "@typescript-eslint/eslint-plugin": "^2.27.0",
     "@typescript-eslint/parser": "^2.27.0",

--- a/packages/@glimmerx/babel-plugin-component-templates/package.json
+++ b/packages/@glimmerx/babel-plugin-component-templates/package.json
@@ -15,8 +15,8 @@
   "dependencies": {
     "@babel/core": "^7.9.0",
     "@babel/helper-module-imports": "^7.8.3",
-    "@glimmer/babel-plugin-strict-template-precompile": "2.0.0-beta.7",
-    "@glimmer/syntax": "^0.50.1"
+    "@glimmer/babel-plugin-strict-template-precompile": "2.0.0-beta.11",
+    "@glimmer/syntax": "0.62.4"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.9.5",

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-declaration/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-declaration/output.js
@@ -5,8 +5,8 @@ import Component from '@glimmerx/component';
 class MyComponent extends Component {}
 
 _setComponentTemplate({
-  id: "2nwO9ZJ8",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,0,0,0,[31,6,2,[27,[26,0,\"CallHead\"],[]],[\"foo\"],null]],[11]],\"hasEval\":false,\"upvars\":[\"_t\"]}",
+  id: "tBsr36lW",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[1,[30,[36,0],[\"foo\"],null]],[13]],\"hasEval\":false,\"upvars\":[\"_t\"]}",
   meta: {
     scope: () => ({
       _t: _t

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-expression/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/class-expression/output.js
@@ -3,8 +3,8 @@ import { t as _t } from "t-helper";
 import Component from '@glimmerx/component';
 
 const MyComponent = _setComponentTemplate({
-  id: "2nwO9ZJ8",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,0,0,0,[31,6,2,[27,[26,0,\"CallHead\"],[]],[\"foo\"],null]],[11]],\"hasEval\":false,\"upvars\":[\"_t\"]}",
+  id: "tBsr36lW",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[1,[30,[36,0],[\"foo\"],null]],[13]],\"hasEval\":false,\"upvars\":[\"_t\"]}",
   meta: {
     scope: () => ({
       _t: _t

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/template-only-component/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat/template-only-component/output.js
@@ -3,8 +3,8 @@ import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 import { t as _t } from "t-helper";
 
 const someTemplate = _setComponentTemplate({
-  id: "2nwO9ZJ8",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,0,0,0,[31,6,2,[27,[26,0,\"CallHead\"],[]],[\"foo\"],null]],[11]],\"hasEval\":false,\"upvars\":[\"_t\"]}",
+  id: "tBsr36lW",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[1,[30,[36,0],[\"foo\"],null]],[13]],\"hasEval\":false,\"upvars\":[\"_t\"]}",
   meta: {
     scope: () => ({
       _t: _t

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform-hbs/output.js
@@ -2,8 +2,8 @@ import { templateOnlyComponent as _templateOnlyComponent } from "@glimmer/core";
 import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 
 const template = _setComponentTemplate({
-  id: "k5+y7pkD",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "iLYq0mJl",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello world\"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-options/precompile/ast-transform/output.js
@@ -4,8 +4,8 @@ import Component from '@glimmerx/component';
 class MyComponent extends Component {}
 
 _setComponentTemplate({
-  id: "k5+y7pkD",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "iLYq0mJl",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello world\"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-declaration/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-declaration/output.js
@@ -8,8 +8,8 @@ const maybeModifier = null;
 class MyComponent extends Component {}
 
 _setComponentTemplate({
-  id: "hNaOsjkR",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",false],[3,0,0,[27,[26,0,\"ModifierHead\"],[]],null,null],[10],[1,1,0,0,\"Hello world \"],[1,0,0,0,[27,[26,1,\"AppendSingleId\"],[]]],[7,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[7,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[11]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
+  id: "fmofmZv3",
+  block: "{\"symbols\":[],\"statements\":[[11,\"h1\"],[4,[38,0],null,null],[12],[2,\"Hello world \"],[1,[34,1]],[8,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[8,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[13]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
   meta: {
     scope: () => ({
       unknownValue: unknownValue,

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-expression/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-expression/output.js
@@ -2,8 +2,8 @@ import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 import Component from '@glimmerx/component';
 
 const MyComponent = _setComponentTemplate({
-  id: "hzw7dJc0",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "9bMgfwbA",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello world\"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/custom-imports/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/custom-imports/output.js
@@ -5,16 +5,16 @@ import Component from '@glimmerx/component';
 class Class1Declaration extends Component {}
 
 _dangerouslySetComponentTemplate({
-  id: "hzw7dJc0",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "9bMgfwbA",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello world\"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
 }, Class1Declaration)
 
 const Class1Expression = _dangerouslySetComponentTemplate({
-  id: "hzw7dJc0",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "9bMgfwbA",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello world\"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
@@ -23,16 +23,16 @@ const Class1Expression = _dangerouslySetComponentTemplate({
 class Class2Declaration extends Component {}
 
 _dangerouslySetComponentTemplate({
-  id: "85zTPBgs",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"\\n    Goodbye world\\n  \"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "+VA0BbEt",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h2\"],[12],[2,\"\\n    Goodbye world\\n  \"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
 }, Class2Declaration)
 
 const Class2Expression = _dangerouslySetComponentTemplate({
-  id: "64616wXU",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"\\n    Goodbye world\"],[7,\"Class2Declaration\",[],[[],[]],null],[1,1,0,0,\"\\n  \"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "uIjvs0yQ",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h2\"],[12],[2,\"\\n    Goodbye world\"],[8,\"Class2Declaration\",[],[[],[]],null],[2,\"\\n  \"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({
       Class2Declaration: Class2Declaration
@@ -41,8 +41,8 @@ const Class2Expression = _dangerouslySetComponentTemplate({
 }, class extends Component {});
 
 const TOComponent = _dangerouslySetComponentTemplate({
-  id: "iXWF5ni9",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h3\",true],[10],[1,1,0,0,\"Hello again world\"],[7,\"Class2Expression\",[],[[],[]],null],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "tsv3hFVE",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h3\"],[12],[2,\"Hello again world\"],[8,\"Class2Expression\",[],[[],[]],null],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({
       Class2Expression: Class2Expression

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/ember/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/ember/output.js
@@ -8,8 +8,8 @@ const maybeModifier = null;
 class MyComponent extends Component {}
 
 _setComponentTemplate({
-  id: "hNaOsjkR",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",false],[3,0,0,[27,[26,0,\"ModifierHead\"],[]],null,null],[10],[1,1,0,0,\"Hello world \"],[1,0,0,0,[27,[26,1,\"AppendSingleId\"],[]]],[7,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[7,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[11]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
+  id: "fmofmZv3",
+  block: "{\"symbols\":[],\"statements\":[[11,\"h1\"],[4,[38,0],null,null],[12],[2,\"Hello world \"],[1,[34,1]],[8,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[8,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[13]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
   meta: {
     scope: () => ({
       unknownValue: unknownValue,

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/glimmer-env/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/glimmer-env/output.js
@@ -13,8 +13,8 @@ if (true
 class MyComponent extends Component {}
 
 _setComponentTemplate({
-  id: "hNaOsjkR",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",false],[3,0,0,[27,[26,0,\"ModifierHead\"],[]],null,null],[10],[1,1,0,0,\"Hello world \"],[1,0,0,0,[27,[26,1,\"AppendSingleId\"],[]]],[7,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[7,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[11]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
+  id: "fmofmZv3",
+  block: "{\"symbols\":[],\"statements\":[[11,\"h1\"],[4,[38,0],null,null],[12],[2,\"Hello world \"],[1,[34,1]],[8,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[8,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[13]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
   meta: {
     scope: () => ({
       unknownValue: unknownValue,

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-commonjs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-commonjs/output.js
@@ -9,15 +9,15 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 class Class1Declaration extends _component.default {}
 
 (0, _core.setComponentTemplate)({
-  id: "hzw7dJc0",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "9bMgfwbA",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello world\"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
 }, Class1Declaration)
 const Class1Expression = (0, _core.setComponentTemplate)({
-  id: "hzw7dJc0",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "9bMgfwbA",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello world\"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
@@ -26,15 +26,15 @@ const Class1Expression = (0, _core.setComponentTemplate)({
 class Class2Declaration extends _component.default {}
 
 (0, _core.setComponentTemplate)({
-  id: "85zTPBgs",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"\\n    Goodbye world\\n  \"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "+VA0BbEt",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h2\"],[12],[2,\"\\n    Goodbye world\\n  \"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
 }, Class2Declaration)
 const Class2Expression = (0, _core.setComponentTemplate)({
-  id: "d1fbtzoG",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"\\n    Goodbye world\"],[7,\"Class1Expression\",[],[[],[]],null],[1,1,0,0,\"\\n  \"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "U1swtToI",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h2\"],[12],[2,\"\\n    Goodbye world\"],[8,\"Class1Expression\",[],[[],[]],null],[2,\"\\n  \"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({
       Class1Expression: Class1Expression

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-same-scope-var-commonjs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes-same-scope-var-commonjs/output.js
@@ -11,8 +11,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 class MyComponent extends _component.default {}
 
 (0, _core.setComponentTemplate)({
-  id: "wvnbwYrJ",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello \"],[7,\"ExternalComponent\",[],[[],[]],null],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "KK5UHDcn",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello \"],[8,\"ExternalComponent\",[],[[],[]],null],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({
       ExternalComponent: _somewhere.OtherComponent
@@ -23,8 +23,8 @@ class MyComponent extends _component.default {}
 class OtherComponent extends _component.default {}
 
 (0, _core.setComponentTemplate)({
-  id: "wvnbwYrJ",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello \"],[7,\"ExternalComponent\",[],[[],[]],null],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "KK5UHDcn",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello \"],[8,\"ExternalComponent\",[],[[],[]],null],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({
       ExternalComponent: _somewhere.OtherComponent

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiple-classes/output.js
@@ -4,16 +4,16 @@ import Component from '@glimmerx/component';
 class Class1Declaration extends Component {}
 
 _setComponentTemplate({
-  id: "hzw7dJc0",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "9bMgfwbA",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello world\"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
 }, Class1Declaration)
 
 const Class1Expression = _setComponentTemplate({
-  id: "hzw7dJc0",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "9bMgfwbA",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello world\"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
@@ -22,16 +22,16 @@ const Class1Expression = _setComponentTemplate({
 class Class2Declaration extends Component {}
 
 _setComponentTemplate({
-  id: "85zTPBgs",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"\\n    Goodbye world\\n  \"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "+VA0BbEt",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h2\"],[12],[2,\"\\n    Goodbye world\\n  \"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }
 }, Class2Declaration)
 
 const Class2Expression = _setComponentTemplate({
-  id: "d1fbtzoG",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"\\n    Goodbye world\"],[7,\"Class1Expression\",[],[[],[]],null],[1,1,0,0,\"\\n  \"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "U1swtToI",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h2\"],[12],[2,\"\\n    Goodbye world\"],[8,\"Class1Expression\",[],[[],[]],null],[2,\"\\n  \"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({
       Class1Expression: Class1Expression

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiscope-tokens/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/multiscope-tokens/output.js
@@ -7,8 +7,8 @@ import SecondPhantomComponent from './SecondPhantomComponent';
 class MyComponent extends Component {}
 
 _setComponentTemplate({
-  id: "UYRxK3x4",
-  block: "{\"symbols\":[\"SecondPhantomComponent\"],\"statements\":[[1,1,0,0,\"\\n    \"],[9,\"h1\",true],[10],[1,1,0,0,\"Hello world \\n\"],[5,[27,[26,0,\"BlockHead\"],[]],null,null,[[\"default\"],[{\"statements\":[[1,1,0,0,\"            \"],[7,[27,[24,1],[]],[],[[],[]],null],[1,1,0,0,\"\\n            \"],[1,0,0,0,[27,[24,1],[]]],[1,1,0,0,\"\\n\"]],\"parameters\":[1]}]]],[1,1,0,0,\"        \"],[7,\"SecondPhantomComponent\",[],[[],[]],null],[1,1,0,0,\"\\n    \"],[11]],\"hasEval\":false,\"upvars\":[\"OtherComponent\"]}",
+  id: "rfDBNlmm",
+  block: "{\"symbols\":[\"SecondPhantomComponent\"],\"statements\":[[2,\"\\n    \"],[10,\"h1\"],[12],[2,\"Hello world \\n\"],[6,[37,0],null,null,[[\"default\"],[{\"statements\":[[2,\"            \"],[8,[32,1],[],[[],[]],null],[2,\"\\n            \"],[1,[32,1]],[2,\"\\n\"]],\"parameters\":[1]}]]],[2,\"        \"],[8,\"SecondPhantomComponent\",[],[[],[]],null],[2,\"\\n    \"],[13]],\"hasEval\":false,\"upvars\":[\"OtherComponent\"]}",
   meta: {
     scope: () => ({
       OtherComponent: OtherComponent,

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/nested-classes/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/nested-classes/output.js
@@ -5,8 +5,8 @@ import OtherComponent from './OtherComponent';
 class MyComponent extends Component {
   get ChildComponent() {
     return _setComponentTemplate({
-      id: "z5SJXwaW",
-      block: "{\"symbols\":[],\"statements\":[[9,\"h2\",true],[10],[1,1,0,0,\"Goodbye world\"],[7,\"MyComponent\",[],[[],[]],null],[11]],\"hasEval\":false,\"upvars\":[]}",
+      id: "+zgtSPG4",
+      block: "{\"symbols\":[],\"statements\":[[10,\"h2\"],[12],[2,\"Goodbye world\"],[8,\"MyComponent\",[],[[],[]],null],[13]],\"hasEval\":false,\"upvars\":[]}",
       meta: {
         scope: () => ({
           MyComponent: MyComponent
@@ -18,8 +18,8 @@ class MyComponent extends Component {
 }
 
 _setComponentTemplate({
-  id: "O/CNYunf",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\"],[7,\"OtherComponent\",[],[[],[]],null],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "9oyaIEZ1",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello world\"],[8,\"OtherComponent\",[],[[],[]],null],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({
       OtherComponent: OtherComponent

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/phantom-scope/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/phantom-scope/output.js
@@ -6,8 +6,8 @@ import PhantomComponent from './PhantomComponent';
 class MyComponent extends Component {}
 
 _setComponentTemplate({
-  id: "CUkt0JBr",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello world \"],[7,\"OtherComponent\",[],[[],[]],null],[1,1,0,0,\" \"],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "6F9NpduU",
+  block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[2,\"Hello world \"],[8,\"OtherComponent\",[],[[],[]],null],[2,\" \"],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({
       OtherComponent: OtherComponent

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens-hbs/output.js
@@ -5,8 +5,8 @@ import PhantomComponent from './PhantomComponent';
 import SecondPhantomComponent from './SecondPhantomComponent';
 
 const hbsOnlyTemplate = _setComponentTemplate({
-  id: "ZciCU0lx",
-  block: "{\"symbols\":[\"PhantomComponent\",\"SecondPhantomComponent\"],\"statements\":[[1,1,0,0,\"\\n\"],[9,\"h1\",true],[10],[1,1,0,0,\"Hello world\\n\"],[5,[27,[26,0,\"BlockHead\"],[]],null,null,[[\"default\"],[{\"statements\":[[1,1,0,0,\"        \"],[7,[27,[24,2],[]],[],[[],[]],null],[1,1,0,0,\"\\n        \"],[1,0,0,0,[27,[24,2],[]]],[1,1,0,0,\"\\n\"]],\"parameters\":[2]}]]],[1,1,0,0,\"    \"],[7,\"OtherComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[1,1,0,0,\"\\n        \"],[7,[27,[24,1],[]],[],[[],[]],null],[1,1,0,0,\"\\n        \"],[1,0,0,0,[27,[24,1],[]]],[1,1,0,0,\"\\n    \"]],\"parameters\":[1]}]]],[1,1,0,0,\"\\n\"],[11]],\"hasEval\":false,\"upvars\":[\"OtherComponent\"]}",
+  id: "RtPlmZCI",
+  block: "{\"symbols\":[\"PhantomComponent\",\"SecondPhantomComponent\"],\"statements\":[[2,\"\\n\"],[10,\"h1\"],[12],[2,\"Hello world\\n\"],[6,[37,0],null,null,[[\"default\"],[{\"statements\":[[2,\"        \"],[8,[32,2],[],[[],[]],null],[2,\"\\n        \"],[1,[32,2]],[2,\"\\n\"]],\"parameters\":[2]}]]],[2,\"    \"],[8,\"OtherComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[2,\"\\n        \"],[8,[32,1],[],[[],[]],null],[2,\"\\n        \"],[1,[32,1]],[2,\"\\n    \"]],\"parameters\":[1]}]]],[2,\"\\n\"],[13]],\"hasEval\":false,\"upvars\":[\"OtherComponent\"]}",
   meta: {
     scope: () => ({
       OtherComponent: OtherComponent

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/scoped-tokens/output.js
@@ -7,8 +7,8 @@ import SecondPhantomComponent from './SecondPhantomComponent';
 class MyComponent extends Component {}
 
 _setComponentTemplate({
-  id: "Ao8DUTes",
-  block: "{\"symbols\":[\"PhantomComponent\",\"SecondPhantomComponent\"],\"statements\":[[1,1,0,0,\"\\n    \"],[9,\"h1\",true],[10],[1,1,0,0,\"Hello world \\n\"],[5,[27,[26,0,\"BlockHead\"],[]],null,null,[[\"default\"],[{\"statements\":[[1,1,0,0,\"            \"],[7,[27,[24,2],[]],[],[[],[]],null],[1,1,0,0,\"\\n            \"],[1,0,0,0,[27,[24,2],[]]],[1,1,0,0,\"\\n\"]],\"parameters\":[2]}]]],[1,1,0,0,\"        \"],[7,\"OtherComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[1,1,0,0,\"\\n            \"],[7,[27,[24,1],[]],[],[[],[]],null],[1,1,0,0,\" \\n            \"],[1,0,0,0,[27,[24,1],[]]],[1,1,0,0,\"\\n        \"]],\"parameters\":[1]}]]],[1,1,0,0,\"\\n    \"],[11]],\"hasEval\":false,\"upvars\":[\"OtherComponent\"]}",
+  id: "gcTTvmeO",
+  block: "{\"symbols\":[\"PhantomComponent\",\"SecondPhantomComponent\"],\"statements\":[[2,\"\\n    \"],[10,\"h1\"],[12],[2,\"Hello world \\n\"],[6,[37,0],null,null,[[\"default\"],[{\"statements\":[[2,\"            \"],[8,[32,2],[],[[],[]],null],[2,\"\\n            \"],[1,[32,2]],[2,\"\\n\"]],\"parameters\":[2]}]]],[2,\"        \"],[8,\"OtherComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[2,\"\\n            \"],[8,[32,1],[],[[],[]],null],[2,\" \\n            \"],[1,[32,1]],[2,\"\\n        \"]],\"parameters\":[1]}]]],[2,\"\\n    \"],[13]],\"hasEval\":false,\"upvars\":[\"OtherComponent\"]}",
   meta: {
     scope: () => ({
       OtherComponent: OtherComponent

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs-with-component-import/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs-with-component-import/output.js
@@ -3,8 +3,8 @@ import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 import { renderComponent } from '@glimmer/core';
 import IamGlimmerComponent from '@glimmerx/component';
 renderComponent(_setComponentTemplate({
-  id: "wr1/fM82",
-  block: "{\"symbols\":[\"@name\"],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello \"],[1,0,0,0,[27,[24,1],[]]],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "2HWpeZsH",
+  block: "{\"symbols\":[\"@name\"],\"statements\":[[10,\"h1\"],[12],[2,\"Hello \"],[1,[32,1]],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/template-only-hbs/output.js
@@ -2,8 +2,8 @@ import { templateOnlyComponent as _templateOnlyComponent } from "@glimmer/core";
 import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
 import { renderComponent } from '@glimmer/core';
 renderComponent(_setComponentTemplate({
-  id: "wr1/fM82",
-  block: "{\"symbols\":[\"@name\"],\"statements\":[[9,\"h1\",true],[10],[1,1,0,0,\"Hello \"],[1,0,0,0,[27,[24,1],[]]],[11]],\"hasEval\":false,\"upvars\":[]}",
+  id: "2HWpeZsH",
+  block: "{\"symbols\":[\"@name\"],\"statements\":[[10,\"h1\"],[12],[2,\"Hello \"],[1,[32,1]],[13]],\"hasEval\":false,\"upvars\":[]}",
   meta: {
     scope: () => ({})
   }

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/typescript/output.ts
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/typescript/output.ts
@@ -9,8 +9,8 @@ export function foo() {
 export class MyComponent extends Component {}
 
 _setComponentTemplate({
-  id: "hNaOsjkR",
-  block: "{\"symbols\":[],\"statements\":[[9,\"h1\",false],[3,0,0,[27,[26,0,\"ModifierHead\"],[]],null,null],[10],[1,1,0,0,\"Hello world \"],[1,0,0,0,[27,[26,1,\"AppendSingleId\"],[]]],[7,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[7,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[11]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
+  id: "fmofmZv3",
+  block: "{\"symbols\":[],\"statements\":[[11,\"h1\"],[4,[38,0],null,null],[12],[2,\"Hello world \"],[1,[34,1]],[8,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[8,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[13]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
   meta: {
     scope: () => ({
       MaybeComponent: MaybeComponent,

--- a/packages/@glimmerx/blueprint/files/package.json
+++ b/packages/@glimmerx/blueprint/files/package.json
@@ -20,7 +20,7 @@
     "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-typescript": "^7.9.0",
-    "@glimmer/babel-plugin-glimmer-env": "~2.0.0-beta.7",
+    "@glimmer/babel-plugin-glimmer-env": "~2.0.0-beta.11",
     "@glimmer/env": "^0.1.7",
     "@glimmerx/babel-plugin-component-templates": "^0.2.3",
     "@glimmerx/component": "^0.2.3",

--- a/packages/@glimmerx/blueprint/package.json
+++ b/packages/@glimmerx/blueprint/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/glimmerjs/glimmer-experimental#readme",
   "dependencies": {
-    "@glimmer/blueprint": "2.0.0-beta.7",
+    "@glimmer/blueprint": "2.0.0-beta.11",
     "ember-cli-string-utils": "^1.1.0",
     "walk-sync": "^2.0.2"
   },

--- a/packages/@glimmerx/component/index.ts
+++ b/packages/@glimmerx/component/index.ts
@@ -1,6 +1,8 @@
+import { default as Component } from '@glimmer/component';
+
 export { default } from '@glimmer/component';
 export { tracked } from '@glimmer/tracking';
 
-export function hbs(_strings: TemplateStringsArray) {
+export function hbs(_strings: TemplateStringsArray): Component {
   throw new Error('hbs template should have been compiled at build time');
 }

--- a/packages/@glimmerx/component/package.json
+++ b/packages/@glimmerx/component/package.json
@@ -15,8 +15,8 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/component": "2.0.0-beta.7",
-    "@glimmer/tracking": "2.0.0-beta.7",
+    "@glimmer/component": "2.0.0-beta.11",
+    "@glimmer/tracking": "2.0.0-beta.11",
     "@glimmerx/babel-plugin-component-templates": "^0.2.5",
     "ember-cli-babel": "^7.17.2",
     "ember-cli-babel-plugin-helpers": "^1.1.0"

--- a/packages/@glimmerx/core/package.json
+++ b/packages/@glimmerx/core/package.json
@@ -17,8 +17,8 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/core": "2.0.0-beta.7",
-    "@glimmer/interfaces": "^0.50.1"
+    "@glimmer/core": "2.0.0-beta.11",
+    "@glimmer/interfaces": "0.62.4"
   },
   "volta": {
     "node": "12.10.0",

--- a/packages/@glimmerx/core/src/renderComponent.ts
+++ b/packages/@glimmerx/core/src/renderComponent.ts
@@ -26,9 +26,9 @@ export default function renderComponent(
     return glimmerJsRenderComponent(ComponentClass, optionsOrElement);
   }
 
-  const { element, args, services } = optionsOrElement;
+  const { element, args, services, rehydrate } = optionsOrElement;
 
   const owner = new Owner(services ?? {});
 
-  return glimmerJsRenderComponent(ComponentClass, { element, args, owner });
+  return glimmerJsRenderComponent(ComponentClass, { element, args, owner, rehydrate });
 }

--- a/packages/@glimmerx/helper/package.json
+++ b/packages/@glimmerx/helper/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@glimmerx/core": "0.2.5",
-    "@glimmer/helper": "2.0.0-beta.7",
-    "@glimmer/interfaces": "^0.50.1",
+    "@glimmer/helper": "2.0.0-beta.11",
+    "@glimmer/interfaces": "0.62.4",
     "ember-cli-babel": "^7.18.0"
   },
   "volta": {

--- a/packages/@glimmerx/modifier/package.json
+++ b/packages/@glimmerx/modifier/package.json
@@ -20,8 +20,8 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/core": "2.0.0-beta.7",
-    "@glimmer/modifier": "2.0.0-beta.7",
+    "@glimmer/core": "2.0.0-beta.11",
+    "@glimmer/modifier": "2.0.0-beta.11",
     "ember-cli-babel": "^7.18.0"
   },
   "volta": {

--- a/packages/@glimmerx/ssr/package.json
+++ b/packages/@glimmerx/ssr/package.json
@@ -15,8 +15,8 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/interfaces": "^0.50.1",
-    "@glimmer/ssr": "2.0.0-beta.7",
+    "@glimmer/interfaces": "0.62.4",
+    "@glimmer/ssr": "2.0.0-beta.11",
     "@glimmerx/core": "^0.2.5"
   },
   "volta": {

--- a/packages/@glimmerx/ssr/src/render.ts
+++ b/packages/@glimmerx/ssr/src/render.ts
@@ -12,19 +12,19 @@ export interface RenderOptions extends Omit<GlimmerJsRenderOptions, 'owner'> {
 
 export function renderToString(
   definition: ComponentDefinition,
-  { args, serializer, services }: RenderOptions = {}
+  { args, serializer, services, rehydrate }: RenderOptions = {}
 ): Promise<string> {
   const owner = new Owner(services ?? {});
 
-  return glimmerJsRenderToString(definition, { args, serializer, owner });
+  return glimmerJsRenderToString(definition, { args, serializer, owner, rehydrate });
 }
 
 export function renderToStream(
   stream: NodeJS.WritableStream,
   definition: ComponentDefinition,
-  { args, serializer, services }: RenderOptions = {}
+  { args, serializer, services, rehydrate }: RenderOptions = {}
 ): void {
   const owner = new Owner(services ?? {});
 
-  glimmerJsRenderToStream(stream, definition, { args, serializer, owner });
+  glimmerJsRenderToStream(stream, definition, { args, serializer, owner, rehydrate });
 }

--- a/packages/@glimmerx/storybook/package.json
+++ b/packages/@glimmerx/storybook/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-decorators": "^7.8.3",
-    "@glimmer/babel-plugin-strict-template-precompile": "2.0.0-beta.7",
+    "@glimmer/babel-plugin-strict-template-precompile": "2.0.0-beta.11",
     "@glimmerx/babel-plugin-component-templates": "^0.2.5",
     "@glimmerx/component": "^0.2.5",
     "@glimmerx/core": "^0.2.5",

--- a/packages/examples/basic-addon/package.json
+++ b/packages/examples/basic-addon/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
-    "@glimmer/tracking": "2.0.0-beta.7",
+    "@glimmer/tracking": "2.0.0-beta.11",
     "@glimmerx/eslint-plugin": "^0.2.5",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/examples/basic/package.json
+++ b/packages/examples/basic/package.json
@@ -17,7 +17,7 @@
     "basic-addon": "0.2.5"
   },
   "devDependencies": {
-    "@glimmer/interfaces": "^0.50.1",
+    "@glimmer/interfaces": "0.62.4",
     "@glimmerx/storybook": "^0.2.5"
   },
   "volta": {

--- a/packages/examples/ember-app/package.json
+++ b/packages/examples/ember-app/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
     "@glimmer/component": "^1.0.0",
-    "@glimmer/tracking": "2.0.0-beta.7",
+    "@glimmer/tracking": "2.0.0-beta.11",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^1.5.3",

--- a/packages/examples/partial-rehydration/index.ts
+++ b/packages/examples/partial-rehydration/index.ts
@@ -1,0 +1,14 @@
+import { renderComponent } from '@glimmerx/core';
+import RehydratingComponent from './src/RehydratingComponent';
+
+document.addEventListener(
+  'DOMContentLoaded',
+  () => {
+    const element = document.querySelector('.static-component');
+    renderComponent(RehydratingComponent, {
+      element: element!,
+      rehydrate: true,
+    });
+  },
+  { once: true }
+);

--- a/packages/examples/partial-rehydration/package.json
+++ b/packages/examples/partial-rehydration/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "partial-rehydration-example-app",
+  "version": "0.2.5",
+  "description": "Example application using partial rehydration with @glimmerx packages",
+  "main": "dist/commonjs/index.js",
+  "repository": "https://github.com/glimmerjs/glimmer-experimental",
+  "author": "Chirag Patel",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+  },
+  "dependencies": {
+    "@glimmerx/core": "^0.2.5",
+    "@glimmerx/component": "^0.2.5",
+    "@glimmerx/modifier": "^0.2.5",
+    "@glimmerx/ssr": "^0.2.5"
+  },
+  "volta": {
+    "node": "12.10.0",
+    "yarn": "1.22.4"
+  }
+}

--- a/packages/examples/partial-rehydration/server.ts
+++ b/packages/examples/partial-rehydration/server.ts
@@ -1,0 +1,29 @@
+import { renderToString } from '@glimmerx/ssr';
+import StaticComponent from './src/StaticComponent';
+
+interface ExpressResponse {
+  end(str: string): void;
+}
+
+export default async function handler(
+  _: {},
+  res: ExpressResponse,
+  clientsideBundleLocation: string
+): Promise<void> {
+  const ssrOutput = await renderToString(StaticComponent, {
+    rehydrate: true,
+  });
+
+  res.end(`
+      <!doctype html>
+      <html>
+        <head>
+          <title>Glimmer Demo</title>
+        </head>
+        <body>
+          <div id="app">${ssrOutput}</div>
+          <script src="${clientsideBundleLocation}"></script>
+        </body>
+      </html>
+    `);
+}

--- a/packages/examples/partial-rehydration/src/RehydratingComponent.ts
+++ b/packages/examples/partial-rehydration/src/RehydratingComponent.ts
@@ -1,0 +1,15 @@
+import Component, { hbs, tracked } from '@glimmerx/component';
+import { on, action } from '@glimmerx/modifier';
+
+export default class RehydratingComponent extends Component {
+  @tracked count = 1;
+
+  @action increment() {
+    this.count++;
+  }
+
+  static template = hbs`
+    <p>You have clicked the button {{this.count}} times.</p>
+    <button {{on "click" this.increment}}>Click</button>
+  `;
+}

--- a/packages/examples/partial-rehydration/src/StaticComponent.ts
+++ b/packages/examples/partial-rehydration/src/StaticComponent.ts
@@ -1,0 +1,9 @@
+import { hbs } from '@glimmerx/component';
+import RehydratingComponent from './RehydratingComponent';
+
+export default hbs`
+  <div class="static-component">
+    <h1>Hello I am a static component. I don't change after page load.</h1>
+    <RehydratingComponent/>
+  </div>
+`;

--- a/packages/examples/playground/package.json
+++ b/packages/examples/playground/package.json
@@ -20,7 +20,7 @@
     "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-typescript": "^7.9.0",
-    "@glimmer/babel-plugin-glimmer-env": "~2.0.0-beta.7",
+    "@glimmer/babel-plugin-glimmer-env": "~2.0.0-beta.11",
     "@glimmer/env": "^0.1.7",
     "@glimmerx/babel-plugin-component-templates": "^0.2.5",
     "@glimmerx/component": "^0.2.5",

--- a/packages/examples/playground/src/Sandbox.ts
+++ b/packages/examples/playground/src/Sandbox.ts
@@ -7,7 +7,8 @@ function renderSnippet(snippet: string): HTMLElement {
 
   const { default: component, services } = evalSnippet(snippet);
 
-  renderComponent(component, { element, services });
+  // Call renderComponent withing a Promise resolve so that it doesn't get autotracked
+  Promise.resolve().then(() => renderComponent(component, { element, services }));
 
   return element;
 }

--- a/packages/examples/rehydration/index.ts
+++ b/packages/examples/rehydration/index.ts
@@ -1,0 +1,14 @@
+import { renderComponent } from '@glimmerx/core';
+import MyComponent from './src/MyComponent';
+
+document.addEventListener(
+  'DOMContentLoaded',
+  () => {
+    const element = document.getElementById('app');
+    renderComponent(MyComponent, {
+      element: element!,
+      rehydrate: true,
+    });
+  },
+  { once: true }
+);

--- a/packages/examples/rehydration/package.json
+++ b/packages/examples/rehydration/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "rehydration-example-app",
+  "version": "0.2.5",
+  "description": "Example application using rehydration with @glimmerx packages",
+  "main": "dist/commonjs/index.js",
+  "repository": "https://github.com/glimmerjs/glimmer-experimental",
+  "author": "Chirag Patel",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+  },
+  "dependencies": {
+    "@glimmerx/core": "^0.2.5",
+    "@glimmerx/component": "^0.2.5",
+    "@glimmerx/modifier": "^0.2.5",
+    "@glimmerx/ssr": "^0.2.5"
+  },
+  "volta": {
+    "node": "12.10.0",
+    "yarn": "1.22.4"
+  }
+}

--- a/packages/examples/rehydration/server.ts
+++ b/packages/examples/rehydration/server.ts
@@ -1,0 +1,29 @@
+import { renderToString } from '@glimmerx/ssr';
+import MyComponent from './src/MyComponent';
+
+interface ExpressResponse {
+  end(str: string): void;
+}
+
+export default async function handler(
+  _: {},
+  res: ExpressResponse,
+  clientsideBundleLocation: string
+) {
+  const ssrOutput = await renderToString(MyComponent, {
+    rehydrate: true,
+  });
+
+  res.end(`
+      <!doctype html>
+      <html>
+        <head>
+          <title>Glimmer Demo</title>
+        </head>
+        <body>
+          <div id="app">${ssrOutput}</div>
+          <script src="${clientsideBundleLocation}"></script>
+        </body>
+      </html>
+    `);
+}

--- a/packages/examples/rehydration/src/MyComponent.ts
+++ b/packages/examples/rehydration/src/MyComponent.ts
@@ -1,0 +1,15 @@
+import Component, { hbs, tracked } from '@glimmerx/component';
+import { on, action } from '@glimmerx/modifier';
+
+export default class HelloWorld extends Component {
+  @tracked count = 1;
+
+  @action increment() {
+    this.count++;
+  }
+
+  static template = hbs`
+    <p>You have clicked the button {{this.count}} times.</p>
+    <button {{on "click" this.increment}}>Click</button>
+  `;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,34 +1,17 @@
 const path = require('path');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
-module.exports = {
-  entry: {
-    app: './packages/examples/basic/index.ts',
-    tests: './tests/index.ts',
-    nodeTests: './tests/node.ts',
-  },
+const commonBabelPlugins = [
+  ['@glimmer/babel-plugin-glimmer-env', { DEBUG: true }],
+  '@glimmerx/babel-plugin-component-templates',
+  ['@babel/plugin-proposal-decorators', { legacy: true }],
+  '@babel/plugin-proposal-class-properties',
+];
+
+const commonConfig = {
   mode: 'development',
   externals: {
     fs: 'fs',
-  },
-  module: {
-    rules: [
-      {
-        test: /(\.ts|\.js)$/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            plugins: [
-              ['@glimmer/babel-plugin-glimmer-env', { DEBUG: true }],
-              '@glimmerx/babel-plugin-component-templates',
-              ['@babel/plugin-proposal-decorators', { legacy: true }],
-              '@babel/plugin-proposal-class-properties',
-            ],
-            presets: ['@babel/preset-typescript', '@babel/preset-env'],
-          },
-        },
-      },
-    ],
   },
   resolve: {
     plugins: [
@@ -44,5 +27,85 @@ module.exports = {
   },
   devServer: {
     writeToDisk: true,
+    before: (app) => {
+      app.get('/rehydration', (req, res) => {
+        const { default: handler } = require('./dist/rehydrationNodeServer.bundle.js');
+        handler(req, res, './rehydration.bundle.js');
+      });
+
+      app.get('/partial-rehydration', (req, res) => {
+        const { default: handler } = require('./dist/partialRehydrationNodeServer.bundle.js');
+        handler(req, res, './partialRehydration.bundle.js');
+      });
+    },
   },
 };
+
+const browserConfig = {
+  ...commonConfig,
+  entry: {
+    app: './packages/examples/basic/index.ts',
+    rehydration: './packages/examples/rehydration/index.ts',
+    partialRehydration: './packages/examples/partial-rehydration/index.ts',
+    nodeTests: './tests/node.ts',
+    tests: './tests/index.ts',
+  },
+  module: {
+    rules: [
+      {
+        test: /(\.ts|\.js)$/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            plugins: commonBabelPlugins,
+            presets: ['@babel/preset-typescript', '@babel/preset-env'],
+          },
+        },
+      },
+    ],
+  },
+};
+
+const nodeConfig = {
+  ...commonConfig,
+  devtool: false,
+  entry: {
+    rehydrationNodeServer: './packages/examples/rehydration/server.ts',
+    partialRehydrationNodeServer: './packages/examples/partial-rehydration/server.ts',
+  },
+  externals: {
+    ...commonConfig.externals,
+    '@glimmer/validator': '@glimmer/validator',
+  },
+  output: {
+    ...commonConfig.output,
+    libraryTarget: 'umd',
+  },
+  target: 'node',
+  module: {
+    rules: [
+      {
+        test: /(\.ts|\.js)$/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            plugins: commonBabelPlugins,
+            presets: [
+              '@babel/preset-typescript',
+              [
+                '@babel/preset-env',
+                {
+                  targets: {
+                    node: true,
+                  },
+                },
+              ],
+            ],
+          },
+        },
+      },
+    ],
+  },
+};
+
+module.exports = [nodeConfig, browserConfig];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1273,52 +1273,52 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@glimmer/babel-plugin-glimmer-env@2.0.0-beta.7", "@glimmer/babel-plugin-glimmer-env@~2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@glimmer/babel-plugin-glimmer-env/-/babel-plugin-glimmer-env-2.0.0-beta.7.tgz#d26613a38bc343cdbf2023bffb0d08f933e799dd"
-  integrity sha512-TBDJzaUKbtnfJpBymGVbqD/qAepMp7TNYBDqsbz9zs+GD/vDk2JCPKsWmv9CsHu7zYe1drufMFL6HfF+W8bB2w==
+"@glimmer/babel-plugin-glimmer-env@2.0.0-beta.11", "@glimmer/babel-plugin-glimmer-env@~2.0.0-beta.11":
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@glimmer/babel-plugin-glimmer-env/-/babel-plugin-glimmer-env-2.0.0-beta.11.tgz#cfce1bb84e34b885ccc6628803f351fd6b36f5f4"
+  integrity sha512-0+Ghj/vG5knAlR9XGPprKyKRnYeahmywuY7Hs8WAidGDKNvrH7DjaMwmaJNUh+CGCR2Y8MG171VW9o3Ljs6SVw==
   dependencies:
     "@babel/core" "^7.5.5"
     babel-plugin-debug-macros "^0.3.3"
 
-"@glimmer/babel-plugin-strict-template-precompile@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@glimmer/babel-plugin-strict-template-precompile/-/babel-plugin-strict-template-precompile-2.0.0-beta.7.tgz#d2d21e25b0dc7946f7aec610170ead6921e9563d"
-  integrity sha512-6A7tpxGDTLibBkn5+ddiBn4OaTIDV6Fv8Zi/P7wv4xkgzpSsHoZmSV4ytSMdwypF/KrR0iAAwQ8koIstGNXM+w==
+"@glimmer/babel-plugin-strict-template-precompile@2.0.0-beta.11":
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@glimmer/babel-plugin-strict-template-precompile/-/babel-plugin-strict-template-precompile-2.0.0-beta.11.tgz#73b172c138f257a42d16f38d7b1dfd052050235f"
+  integrity sha512-QBkSQAi2GiF1fKeAmyi76/wfXpF5beLJ6rrBpjT4XGTDP0r9FXv6WjXM98KO0O4mbPn+JnUiHrsr9l3TR/ppzQ==
   dependencies:
     "@babel/core" "^7.5.5"
     "@babel/generator" "^7.9.4"
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/parser" "^7.9.4"
     "@babel/types" "^7.9.0"
-    "@glimmer/compiler" "0.51.0"
+    "@glimmer/compiler" "0.62.4"
 
-"@glimmer/blueprint@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@glimmer/blueprint/-/blueprint-2.0.0-beta.7.tgz#b8d511a78174985a95337df033c5dfbca15f7093"
-  integrity sha512-6U1mg6t10zVRkedLHvStEJZHImjn7F1oqwvGQ9E+XwV1BP4WJMRJt7SCj3TeiqLp+rRC70dXA9irtMh3m8wWTA==
+"@glimmer/blueprint@2.0.0-beta.11":
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@glimmer/blueprint/-/blueprint-2.0.0-beta.11.tgz#79a2efe433ad8feb3496ee777fd2a6352dd620e0"
+  integrity sha512-MHO8u5tWbTNws22ZLR61mjojtlMYHJSJ5bwgIK7mu7eGSauuWFTWBYjU8GkBDHkPJvl6tHN1v/EDIdUrhdFcrQ==
   dependencies:
     ember-cli-string-utils "^1.1.0"
 
-"@glimmer/compiler@0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.51.0.tgz#35b287db3da96b8de9ab1efafa49ab041c68398e"
-  integrity sha512-TXQw4AyNJOpHcOlO5h1U3Yf5X9aAfeiC5VJavsNXsNtzx22/RfSalsMXPjc6R4IzLP9ihjlMEK/uG8MncsOUyg==
+"@glimmer/compiler@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.62.4.tgz#15bd2f0a068bc1e03d775948dc5cbddda02a9c19"
+  integrity sha512-Tgubvwlu5XrYl79EDSD/nRgJqTe13+S952tdasH7mxIerfR8o5QOMvCJz+jVv0PxX8zOGZKGo9GQYxKwsWHKDA==
   dependencies:
-    "@glimmer/interfaces" "^0.51.0"
-    "@glimmer/syntax" "^0.51.0"
-    "@glimmer/util" "^0.51.0"
-    "@glimmer/wire-format" "^0.51.0"
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/syntax" "0.62.4"
+    "@glimmer/util" "0.62.4"
+    "@glimmer/wire-format" "0.62.4"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/component@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-2.0.0-beta.7.tgz#7f73c0ac5699d8aa0213af2408a7ed86363a8515"
-  integrity sha512-LDSb2/+0AqVQShG6jan/N7RI5698bkY3QHPv+tH2n3BlE2Hr/ZRJP23dJmaP+AJ7sp/kH+v/SmTfqgGeMXELYA==
+"@glimmer/component@2.0.0-beta.11":
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-2.0.0-beta.11.tgz#25ed7193fd01087ce61dde110ddc70ec96424350"
+  integrity sha512-pt9fU0+Abh8PI3oCwpDmxyS292o2Q70Rjlk/fHDM+yGE05LKfIIrqpTglK474MTPWhns//7IRCbSuM9eAwm/HA==
   dependencies:
-    "@glimmer/core" "2.0.0-beta.7"
+    "@glimmer/core" "2.0.0-beta.11"
     "@glimmer/env" "^0.1.7"
-    "@glimmer/util" "^0.51.0"
+    "@glimmer/util" "0.62.4"
     broccoli-file-creator "^2.1.1"
     broccoli-merge-trees "^3.0.2"
     ember-cli-babel "^7.7.3"
@@ -1327,7 +1327,7 @@
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-path-utils "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-typescript "3.0.0"
+    ember-cli-typescript "^3.0.0"
     ember-compatibility-helpers "^1.1.2"
 
 "@glimmer/component@^1.0.0":
@@ -1349,16 +1349,18 @@
     ember-cli-typescript "3.0.0"
     ember-compatibility-helpers "^1.1.2"
 
-"@glimmer/core@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@glimmer/core/-/core-2.0.0-beta.7.tgz#f7d8d8b2bc6dba9fe077b67046e825b068fda8db"
-  integrity sha512-5hdXekJ5UTMqm/EcRe/1x19ncpHGUcG1+nX7CwuHpHyR36YEjxEAyIEfh0ZJJPuP8pCmJ+osTjMa6ztKFCv17g==
+"@glimmer/core@2.0.0-beta.11":
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@glimmer/core/-/core-2.0.0-beta.11.tgz#4951497ec05ae2b2c6caccd6a96e9e2ed1d97b13"
+  integrity sha512-z+kV+qixXaqxJS/4bAytpi9Jc2QlVGf/dnTDY38t6H3XQW81eaRuL3Ri7UxmCk8tf9ouvSi1HA3xPbxaDCdQug==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/interfaces" "^0.51.0"
-    "@glimmer/opcode-compiler" "^0.51.0"
-    "@glimmer/runtime" "^0.51.0"
-    "@glimmer/validator" "^0.51.0"
+    "@glimmer/global-context" "0.62.4"
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/opcode-compiler" "0.62.4"
+    "@glimmer/program" "0.62.4"
+    "@glimmer/runtime" "0.62.4"
+    "@glimmer/validator" "0.62.4"
     "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/di@^0.1.9":
@@ -1366,28 +1368,42 @@
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.1.11.tgz#a6878c07a13a2c2c76fcde598a5c97637bfc4280"
   integrity sha1-poeMB6E6LCx2/N5ZilyXY3v8QoA=
 
-"@glimmer/encoder@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.51.0.tgz#a8c7dfd760964ecd53d7def550a66e3e9564ba62"
-  integrity sha512-EakrjpISwKf7NQlbo+beq8mxt3njcLt1ciqs51NL8pMDachaCtY57wTUSVXN9URb230dyGxU0VbWMKBeqvjTOA==
+"@glimmer/encoder@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.62.4.tgz#bdf8f73c96db053f6b013563df9e71edd8fd8a69"
+  integrity sha512-iIJ/tD+OFu/g37EC8LCZTldjuPXQmywsHq3A4c91vzPrxElRMH3Crln8+u4X75r6SOhYza5jN7mhNSa0YV2rKw==
   dependencies:
-    "@glimmer/interfaces" "^0.51.0"
-    "@glimmer/vm" "^0.51.0"
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/vm" "0.62.4"
 
 "@glimmer/env@0.1.7", "@glimmer/env@^0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
 
-"@glimmer/helper@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@glimmer/helper/-/helper-2.0.0-beta.7.tgz#c213fdb7dea89343e2039b3d55bda98a55275272"
-  integrity sha512-6d8toFGuN01YA+Izk/m5xkUKdWAieDXOgZYSogamjGfMmFmUJY+VbGTh1Cu5hKA9fdOpccF0lQDqWu5TPWwA+Q==
+"@glimmer/global-context@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/global-context/-/global-context-0.62.4.tgz#6b942b6ca0d23141a88fe707f7ce6bcac6709336"
+  integrity sha512-F1vD6+zURXOzFKYUL7Dw+zDasfYKpBWt/7GJ8lUVNJ7XOZQQOOeY8Tr29K4ZUrqu3lByTqyBR46gpE8UdbsJ2w==
   dependencies:
-    "@glimmer/component" "2.0.0-beta.7"
-    "@glimmer/core" "2.0.0-beta.7"
-    "@glimmer/interfaces" "^0.51.0"
-    "@glimmer/reference" "^0.51.0"
+    "@glimmer/env" "^0.1.7"
+
+"@glimmer/helper@2.0.0-beta.11":
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@glimmer/helper/-/helper-2.0.0-beta.11.tgz#03a33f75d12b864c2b6c278cead8e1f5acd32690"
+  integrity sha512-pzOWkUJe95eQZtJMb3KILXQQQ9hu+d1/az8vtNrqgZwgpbE3iLAUuDsTwOOW050+fMLNr6rkYOghLoLEGYnTgQ==
+  dependencies:
+    "@glimmer/component" "2.0.0-beta.11"
+    "@glimmer/core" "2.0.0-beta.11"
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/reference" "0.62.4"
+
+"@glimmer/interfaces@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.62.4.tgz#e9027d637a0ea80522f29a241aa819e686c623ae"
+  integrity sha512-x3L9YUL17fRgxFrnUvUYTxgnLoh8BipdqkweUEVA5qdIa1dcidUzHUFtWgRiWZ+dKCJBtxh2ubEwjOfgobpMuQ==
+  dependencies:
+    "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/interfaces@^0.50.1":
   version "0.50.1"
@@ -1396,100 +1412,105 @@
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/interfaces@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.51.0.tgz#a25ee61a302bcb8ee45b4b9f7e825a8af5874b49"
-  integrity sha512-QouZvCRnIpeRFAgEsk5T7FXVQ7xzUNRMDPfEfNXoTPlEYkbC2J9BngaTo0U2Un6OGHt/du8DqEw7gXurBe9SNQ==
+"@glimmer/low-level@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.62.4.tgz#db54f646d8ba6362d9e3a3a36f174f5699dbe4fd"
+  integrity sha512-1aNPSfNUs/b3VfQ/DzhKVmIA/JlW30hcDxlitKms8nqmkP6wCgJhurIaU0ksjkIpFyIsZW4ojasAzh/QZ0aEAg==
+
+"@glimmer/modifier@2.0.0-beta.11":
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@glimmer/modifier/-/modifier-2.0.0-beta.11.tgz#a78ef94b533b2566aa12493463da9b0c4efd83dc"
+  integrity sha512-Be6Z8D1FOmjal5B3BP9NV95CjtcPmEswtzY64b79MHLKPS1vAXVZT+8VBI3yZUxDIFvcBnZjfvma0hqUxaTCNA==
   dependencies:
+    "@glimmer/interfaces" "0.62.4"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/low-level@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.51.0.tgz#04c3caf774a9ef458dbd9b07f4955b09873ea27a"
-  integrity sha512-pZit5wGMn8M8Tl/aoeRgNR5v16vr0Q+dsx+2/itA0I+1LubBSqDfZUa3ye2Ut1nwjKY8qzwH7T6gr/ef9taeeQ==
-
-"@glimmer/modifier@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@glimmer/modifier/-/modifier-2.0.0-beta.7.tgz#8cdc7bcfbfc3c902196edd7731159218aaf275cb"
-  integrity sha512-GXpPObr/Dsj71xzN7QKZXYHeWX101j+q0sJwrQH3JkrXVaGohJVTFfRjWsxg1D3Ats/j27QG6Fxu7v/VrdO94w==
+"@glimmer/node@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.62.4.tgz#043ec291f0f3d1e09985bbe0093b5cca22843009"
+  integrity sha512-5EWU65GLF3nhlF7pp/f294kNEbpLut7Wm5OtSnXm9Ku7pnm7alUXBrcKKlT6I6tTxsOpargmuBzZTFfAnimJAA==
   dependencies:
-    "@glimmer/interfaces" "^0.51.0"
-    "@simple-dom/interface" "^1.4.0"
-
-"@glimmer/node@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/node/-/node-0.51.0.tgz#d945c270f2a78ce7767e5e011dbffd8092a6a79c"
-  integrity sha512-G9x7qtpRFPyju17fPMTrP3KRqeKJmlW81seXQM34enKMoB6q84jjLcT3VzpdH7rmqJkfUM7zCqRFTjzP8TixEw==
-  dependencies:
-    "@glimmer/interfaces" "^0.51.0"
-    "@glimmer/runtime" "^0.51.0"
-    "@glimmer/util" "^0.51.0"
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/runtime" "0.62.4"
+    "@glimmer/util" "0.62.4"
     "@simple-dom/document" "^1.4.0"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/opcode-compiler@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.51.0.tgz#30d537648262c95e06f26a46df82209d3958fcc7"
-  integrity sha512-hE2bGKkmga5AfkeAV806UppL/w2/wylDTMfBOu71/ZORYvDdFDCGvzL+bE8yy44e+LteIJhOPvRD7+YvNkRstQ==
+"@glimmer/opcode-compiler@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.62.4.tgz#39b481d42b1575dab61aebfccff9fa5733144185"
+  integrity sha512-a/ty5b6yovmf2d4mj6U9NE/EnlKHRlzGIh0fJD0A3VPO0mVoGQTnI2So6kkI/1u/nSbofULn6v8QarNoLK02uA==
   dependencies:
-    "@glimmer/encoder" "^0.51.0"
-    "@glimmer/interfaces" "^0.51.0"
-    "@glimmer/program" "^0.51.0"
-    "@glimmer/reference" "^0.51.0"
-    "@glimmer/util" "^0.51.0"
-    "@glimmer/vm" "^0.51.0"
-    "@glimmer/wire-format" "^0.51.0"
+    "@glimmer/encoder" "0.62.4"
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/program" "0.62.4"
+    "@glimmer/reference" "0.62.4"
+    "@glimmer/util" "0.62.4"
+    "@glimmer/vm" "0.62.4"
+    "@glimmer/wire-format" "0.62.4"
 
-"@glimmer/program@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.51.0.tgz#02af329dec6241d806ee1962f7aa8d17b6a114c0"
-  integrity sha512-KBZmVSb8wacoB3PwF72xsJV+F+tdXBklS6qqF0GMdJEWJhp53z2jTElSDnODNY2Rf+lnq9u3GrrfZMQmGjkgbw==
+"@glimmer/program@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.62.4.tgz#0ee7cb5cebc4e0f3b2f3c353ce7543d1f8540b7d"
+  integrity sha512-S+wb8Up0Dwxuz8Bzkvw41R199Xu5RXYdoNsRWR2lmj7+ohDuiW8QJp51WyNcfr7ONU5+nqLxp19zNWJzKKIWzw==
   dependencies:
-    "@glimmer/encoder" "^0.51.0"
-    "@glimmer/interfaces" "^0.51.0"
-    "@glimmer/util" "^0.51.0"
+    "@glimmer/encoder" "0.62.4"
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/util" "0.62.4"
 
-"@glimmer/reference@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.51.0.tgz#1d25e088dc91af7884bc4a881202b3ee0cabb094"
-  integrity sha512-tnWa93CRj1O61IoCKgdJh910rgPy1UmV1zAykcSVd26YKS6oqnh6lLMww+apToCJB3llLbp71qzjZVR35eb7Mg==
+"@glimmer/reference@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.62.4.tgz#50dbd0d202ca94f73bbcdfe19ce450ca5c6babdc"
+  integrity sha512-oabqcfZrMB8FoVLZqqD4w0cUcWt1/d8uBGtXKGGNLkrV2smPFJO/rcfFpZq8alMgzqII5F9Q57gRL+qh0AD8og==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/interfaces" "^0.51.0"
-    "@glimmer/util" "^0.51.0"
-    "@glimmer/validator" "^0.51.0"
+    "@glimmer/global-context" "0.62.4"
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/util" "0.62.4"
+    "@glimmer/validator" "0.62.4"
 
-"@glimmer/runtime@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.51.0.tgz#fbde6e563e5532f050ebee6ed2b1f21506c66f80"
-  integrity sha512-RwpaI6K8FGMA39Hw1dzjuXbOuoCsYavW1tZChEO23wZuO2QawggpGXDV9R5czqDYr0k6a2mKs8nZNgTIsf61Yg==
+"@glimmer/runtime@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.62.4.tgz#a519de6c7081b19f5e30e7f2b96168bdfc701607"
+  integrity sha512-aBoCmOWy00lJYriIpnc8Yvx6sQ6sxObiCjvLwD9nN1IwxqfCtqLTwfQr6E98ez0Rl8wMY6M3iTDr9Mvrxt+kVw==
   dependencies:
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "^0.51.0"
-    "@glimmer/low-level" "^0.51.0"
-    "@glimmer/program" "^0.51.0"
-    "@glimmer/reference" "^0.51.0"
-    "@glimmer/util" "^0.51.0"
-    "@glimmer/validator" "^0.51.0"
-    "@glimmer/vm" "^0.51.0"
-    "@glimmer/wire-format" "^0.51.0"
+    "@glimmer/global-context" "0.62.4"
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/low-level" "0.62.4"
+    "@glimmer/program" "0.62.4"
+    "@glimmer/reference" "0.62.4"
+    "@glimmer/util" "0.62.4"
+    "@glimmer/validator" "0.62.4"
+    "@glimmer/vm" "0.62.4"
+    "@glimmer/wire-format" "0.62.4"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/ssr@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@glimmer/ssr/-/ssr-2.0.0-beta.7.tgz#ed96ae5da177fe0ef7b13ea6e15bc12c90bd5d35"
-  integrity sha512-UxfnJAZK8FRTpHSu1ah8FnVTaimPJQtAsFKkhWXEZo+V0ElhSCV+PmXWfPwrRotdNTdaeZowJNbg2dliyBiCNw==
+"@glimmer/ssr@2.0.0-beta.11":
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@glimmer/ssr/-/ssr-2.0.0-beta.11.tgz#85998ae29c0177059f759213e4354bbe41046a5c"
+  integrity sha512-FJIp0u/Io0oQItDVWnT5DnPZA6Gbp3g25LYCodRv4DZE/r4Ha+00cMWKuAbkDSdtYxOd8WigwXK7fOa2yX8h8Q==
   dependencies:
-    "@glimmer/core" "2.0.0-beta.7"
-    "@glimmer/node" "^0.51.0"
-    "@glimmer/reference" "^0.51.0"
-    "@glimmer/runtime" "^0.51.0"
-    "@glimmer/util" "^0.51.0"
+    "@glimmer/core" "2.0.0-beta.11"
+    "@glimmer/node" "0.62.4"
+    "@glimmer/reference" "0.62.4"
+    "@glimmer/runtime" "0.62.4"
+    "@glimmer/util" "0.62.4"
     "@simple-dom/document" "^1.4.0"
     "@simple-dom/serializer" "^1.4.0"
     "@simple-dom/void-map" "^1.4.0"
 
-"@glimmer/syntax@^0.50.0", "@glimmer/syntax@^0.50.1":
+"@glimmer/syntax@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.62.4.tgz#9d5ec15584fed85d807762992a1879fe7fe15ae8"
+  integrity sha512-c/c+tqv1Ob+IaiVYe3DfHsLQwk/DZ3RA14gVcrE8Bbqrr7RtmjdKPfgNswiQhx7b+1ygcUhvYUfxfI8nCVswIw==
+  dependencies:
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/util" "0.62.4"
+    "@handlebars/parser" "^1.1.0"
+    simple-html-tokenizer "^0.5.10"
+
+"@glimmer/syntax@^0.50.0":
   version "0.50.1"
   resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.50.1.tgz#86100fa077d7afd9f82c4e91d194d5d7211516eb"
   integrity sha512-je/0+o/UZukP/lxJJQxgCmk4mUFJpJEAAhqxPtaj054Tofj3X+9CdQwjVU22B8F8j1AIUDr1hRgIop4k0lPbiQ==
@@ -1499,23 +1520,22 @@
     handlebars "^4.5.1"
     simple-html-tokenizer "^0.5.9"
 
-"@glimmer/syntax@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.51.0.tgz#f9d258e9a763e91b751a7dbdb51c0a338da54ba8"
-  integrity sha512-gRmlZBrlAwPj53ZO69SbPi8JXQBrGqheB1OvWtJilTmUKz5nPVt8J5E8ttvS7yotRWrht/jO7qOr3s4GlWp5pA==
-  dependencies:
-    "@glimmer/interfaces" "^0.51.0"
-    "@glimmer/util" "^0.51.0"
-    handlebars "^4.7.4"
-    simple-html-tokenizer "^0.5.9"
-
-"@glimmer/tracking@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-2.0.0-beta.7.tgz#ac27e2ad4d6530a4fb3bff37eb9b71528def6ce9"
-  integrity sha512-YmYUSypcJmL43jgcOC0bgMaGTnZmRwzxQ1DY66sl1agLKkk4xO98/U8lMLsoD5VbhIJHTZELQPTXm1wYnJxcew==
+"@glimmer/tracking@2.0.0-beta.11":
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-2.0.0-beta.11.tgz#874e89c4cf06754a8c73ba429e00f3ce9a545239"
+  integrity sha512-jGA6e30FSfToQtc9h3rlHOJkp/TgUQDWfJmazO1qkPqN9OWV+LA1bHrIoi/7EMo/snZqrA9+rgXzwmZ7mn714Q==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/validator" "^0.51.0"
+    "@glimmer/validator" "0.62.4"
+
+"@glimmer/util@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.62.4.tgz#2e33dd2a8e3e81f5ffc8325fdc9bebb0e274c421"
+  integrity sha512-7x04I4mQpxveAoEbpFfXFFkYpuJoATHuGdwPjgcQc0nSjAkGDkzIMlRN3stgZAz32eSVj9n7SOXHVtHEhw3cCg==
+  dependencies:
+    "@glimmer/env" "0.1.7"
+    "@glimmer/interfaces" "0.62.4"
+    "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/util@^0.44.0":
   version "0.44.0"
@@ -1531,37 +1551,34 @@
     "@glimmer/interfaces" "^0.50.1"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/util@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.51.0.tgz#cb664724608a88bb6c249e34284e54c8ac428831"
-  integrity sha512-FnD+GTD2QsG9YShTBY4GSTd8lAtheXTjJxuZW0OF4Mzeb77kW49lrM0vFh/6OciOqfwQf4rp+7EU0KDFqpGFtg==
-  dependencies:
-    "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "^0.51.0"
-    "@simple-dom/interface" "^1.4.0"
-
-"@glimmer/validator@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.51.0.tgz#3c4074bf7fb774e373caf17d8187afaf367d17e9"
-  integrity sha512-bH7o0FBaYWx7gcKC/5oEL3asQYYDx31N5WNFl9qZ3PjlyPYq73qqwvEbAYbwcByI55a176fnh+mQoUZsDkYGeA==
+"@glimmer/validator@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.62.4.tgz#80570d3fbf9c9a9e6a50e5c022a073da24d14d85"
+  integrity sha512-yZ3cfvbW/S3kAu/EDFCxqMrOp4lWiZ5QxKiDej+GVkuz8yirYVBkf1vZnxogmDyCWLZGvmTr/7QimvQZSHQxVw==
   dependencies:
     "@glimmer/env" "^0.1.7"
+    "@glimmer/global-context" "0.62.4"
 
-"@glimmer/vm@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.51.0.tgz#0e6086ee7801730da1a9c4fb3542a8c94795898f"
-  integrity sha512-s7hbl359mmjVBt9lFAaCHvwnFvJ6T7z+0eh6kjhWmHDCJ7cSzMIcjA/B3psMwzojrEj+xFUHPWZJ2px+8NuQXA==
+"@glimmer/vm@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.62.4.tgz#0c96aa24541f5fdfbfd291a02a854d278affaeeb"
+  integrity sha512-Ug7pipG2gSAXWPHhm6LH1Ow8DEwUOaIy2XGJ5RPZv/ROGOrxGWw4I2Zr46UiJnRdpCs57DkUxUtCn/9saylq4w==
   dependencies:
-    "@glimmer/interfaces" "^0.51.0"
-    "@glimmer/util" "^0.51.0"
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/util" "0.62.4"
 
-"@glimmer/wire-format@^0.51.0":
-  version "0.51.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.51.0.tgz#34264470fce4e109120e2304a45f0eac2c8b4c2e"
-  integrity sha512-OrxNVw41ZKsw32cafR+mlVg8e552sx4NT4Ctg/0aqBv0jfON14eqjM+z3JznHnUbz8HdsrVvH9IdVu2rIP8IVA==
+"@glimmer/wire-format@0.62.4":
+  version "0.62.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.62.4.tgz#ce28c59985486355971bab34625712812a4e2091"
+  integrity sha512-zUWSVkZCgpbNZGb22ksJevDJqKfVOl3JSWHpwel6wpwXWL6BvGjLQwW7+GIKX3gv6qw1K/gJTwsikrHcuExi2g==
   dependencies:
-    "@glimmer/interfaces" "^0.51.0"
-    "@glimmer/util" "^0.51.0"
+    "@glimmer/interfaces" "0.62.4"
+    "@glimmer/util" "0.62.4"
+
+"@handlebars/parser@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
+  integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
 
 "@iarna/toml@2.2.3":
   version "2.2.3"
@@ -8006,6 +8023,26 @@ ember-cli-typescript@^2.0.2:
     stagehand "^1.0.0"
     walk-sync "^1.0.0"
 
+ember-cli-typescript@^3.0.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz#21d6ccd670d1f2e34c9cce68c6e32c442f46806b"
+  integrity sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==
+  dependencies:
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.4.4"
+    "@babel/plugin-proposal-optional-chaining" "^7.6.0"
+    "@babel/plugin-transform-typescript" "~7.8.0"
+    ansi-to-html "^0.6.6"
+    broccoli-stew "^3.0.0"
+    debug "^4.0.0"
+    ember-cli-babel-plugin-helpers "^1.0.0"
+    execa "^3.0.0"
+    fs-extra "^8.0.0"
+    resolve "^1.5.0"
+    rsvp "^4.8.1"
+    semver "^6.3.0"
+    stagehand "^1.0.0"
+    walk-sync "^2.0.0"
+
 ember-cli-typescript@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-3.1.3.tgz#a2c7ec6a8a5e57c38eb52d83e36d8e18c7071e60"
@@ -10248,7 +10285,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
-handlebars@^4.0.11, handlebars@^4.0.4, handlebars@^4.3.1, handlebars@^4.4.0, handlebars@^4.5.1, handlebars@^4.7.3, handlebars@^4.7.4:
+handlebars@^4.0.11, handlebars@^4.0.4, handlebars@^4.3.1, handlebars@^4.4.0, handlebars@^4.5.1, handlebars@^4.7.3:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
   integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
@@ -15889,6 +15926,11 @@ silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0, silent-error@^1.1
   integrity sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==
   dependencies:
     debug "^2.2.0"
+
+simple-html-tokenizer@^0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.10.tgz#0843e4f00c9677f1c81e3dfeefcee0a4aca8e5d0"
+  integrity sha512-1DHMUmvUOGuUZ9/+cX/+hOhWhRD5dEw6lodn8WuV+T+cQ31hhBcCu1dcDsNotowi4mMaNhrLyKoS+DtB81HdDA==
 
 simple-html-tokenizer@^0.5.9:
   version "0.5.9"


### PR DESCRIPTION
**Why**
The new version of glimmer-vm and glimmer.js supports rehydration.
Relevant PRs:
- glimmerjs/glimmer.js#312 
- glimmerjs/glimmer.js#313 
- glimmerjs/glimmer.js#315
- glimmerjs/glimmer-vm#1179

This PR bumps glimmer-vm and glimmer.js versions and adds example applications to see how this feature can be used.

**How**
- Pass through rehydrate flag into glimmer.js render methods
- Modify webpack.config to support server bundles from example apps
- Add new example apps for rehydration and partial rehydration
- Update babel plugin output with the updated compiled template output