### PR TITLE
Read scope variables from current path instead of top level program

### DIFF
--- a/packages/@glimmerx/babel-plugin-component-templates/index.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/index.js
@@ -310,12 +310,10 @@ module.exports = function (babel, options) {
     const templateScopeTokens = getTemplateTokens(templateSource);
 
     const filtered = [];
-    const parentScope = path.scope.getProgramParent();
-
-    Object.values(parentScope.bindings).forEach((binding) => {
-      binding.reference(path);
-
-      if (templateScopeTokens.includes(binding.identifier.name)) {
+    templateScopeTokens.forEach((token) => {
+      const binding = path.scope.getBinding(token);
+      if (binding) {
+        binding.reference(path);
         filtered.push(binding.identifier.name);
       }
     });

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/template-only-component/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures-compat-options/template-only-component/output.js
@@ -6,11 +6,11 @@ import OtherComponent from './OtherComponent';
 import YetAnotherComponent from './YetAnotherComponent';
 
 const template1 = _setComponentTemplate(_createTemplate({
-  OtherComponent: OtherComponent,
-  _t: _t
+  _t: _t,
+  OtherComponent: OtherComponent
 }, `{{_t "bar"}}<h1>Hello world</h1><OtherComponent/>`), _templateOnlyComponent());
 
 const template2 = _setComponentTemplate(_createTemplate({
-  YetAnotherComponent: YetAnotherComponent,
-  _t: _t
+  _t: _t,
+  YetAnotherComponent: YetAnotherComponent
 }, `{{_t "foo"}}<YetAnotherComponent/>`), _templateOnlyComponent());

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-declaration/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/class-declaration/output.js
@@ -12,9 +12,9 @@ _setComponentTemplate({
   block: "{\"symbols\":[],\"statements\":[[11,\"h1\"],[4,[38,0],null,null],[12],[2,\"Hello world \"],[1,[34,1]],[8,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[8,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[13]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
   meta: {
     scope: () => ({
+      maybeModifier: maybeModifier,
       unknownValue: unknownValue,
-      MaybeComponent: MaybeComponent,
-      maybeModifier: maybeModifier
+      MaybeComponent: MaybeComponent
     })
   }
 }, MyComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/ember/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/ember/output.js
@@ -12,9 +12,9 @@ _setComponentTemplate({
   block: "{\"symbols\":[],\"statements\":[[11,\"h1\"],[4,[38,0],null,null],[12],[2,\"Hello world \"],[1,[34,1]],[8,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[8,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[13]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
   meta: {
     scope: () => ({
+      maybeModifier: maybeModifier,
       unknownValue: unknownValue,
-      MaybeComponent: MaybeComponent,
-      maybeModifier: maybeModifier
+      MaybeComponent: MaybeComponent
     })
   }
 }, MyComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/glimmer-env/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/glimmer-env/output.js
@@ -17,9 +17,9 @@ _setComponentTemplate({
   block: "{\"symbols\":[],\"statements\":[[11,\"h1\"],[4,[38,0],null,null],[12],[2,\"Hello world \"],[1,[34,1]],[8,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[8,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[13]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
   meta: {
     scope: () => ({
+      maybeModifier: maybeModifier,
       unknownValue: unknownValue,
-      MaybeComponent: MaybeComponent,
-      maybeModifier: maybeModifier
+      MaybeComponent: MaybeComponent
     })
   }
 }, MyComponent)

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/private-local-declarations/code.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/private-local-declarations/code.js
@@ -1,0 +1,13 @@
+import Component, { hbs } from '@glimmerx/component';
+
+function root() {
+  function nested() {
+    class OtherComponent extends Component {
+      static template = hbs`Hello World`;
+    }
+
+    class MyComponent extends Component {
+      static template = hbs`<h1><OtherComponent/></h1>`
+    }
+  }
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/private-local-declarations/output.js
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/private-local-declarations/output.js
@@ -1,0 +1,28 @@
+import { setComponentTemplate as _setComponentTemplate } from "@glimmer/core";
+import Component from '@glimmerx/component';
+
+function root() {
+  function nested() {
+    class OtherComponent extends Component {}
+
+    _setComponentTemplate({
+      id: "L9WxEO3m",
+      block: "{\"symbols\":[],\"statements\":[[2,\"Hello World\"]],\"hasEval\":false,\"upvars\":[]}",
+      meta: {
+        scope: () => ({})
+      }
+    }, OtherComponent)
+
+    class MyComponent extends Component {}
+
+    _setComponentTemplate({
+      id: "X+3KCppa",
+      block: "{\"symbols\":[],\"statements\":[[10,\"h1\"],[12],[8,\"OtherComponent\",[],[[],[]],null],[13]],\"hasEval\":false,\"upvars\":[]}",
+      meta: {
+        scope: () => ({
+          OtherComponent: OtherComponent
+        })
+      }
+    }, MyComponent)
+  }
+}

--- a/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/typescript/output.ts
+++ b/packages/@glimmerx/babel-plugin-component-templates/test/fixtures/typescript/output.ts
@@ -13,9 +13,9 @@ _setComponentTemplate({
   block: "{\"symbols\":[],\"statements\":[[11,\"h1\"],[4,[38,0],null,null],[12],[2,\"Hello world \"],[1,[34,1]],[8,\"MySubComponent\",[],[[],[]],[[\"default\"],[{\"statements\":[[8,\"MaybeComponent\",[],[[],[]],null]],\"parameters\":[]}]]],[13]],\"hasEval\":false,\"upvars\":[\"maybeModifier\",\"unknownValue\"]}",
   meta: {
     scope: () => ({
-      MaybeComponent: MaybeComponent,
+      maybeModifier: maybeModifier,
       unknownValue: unknownValue,
-      maybeModifier: maybeModifier
+      MaybeComponent: MaybeComponent
     })
   }
 }, MyComponent);

--- a/packages/examples/basic-addon/package.json
+++ b/packages/examples/basic-addon/package.json
@@ -29,7 +29,7 @@
     "@glimmerx/modifier": "^0.3.0",
     "@glimmerx/service": "^0.3.0",
     "ember-cli-babel": "^7.19.0",
-    "ember-cli-htmlbars": "^4.2.3"
+    "ember-cli-htmlbars": "^5.3.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",

--- a/packages/examples/ember-app/package.json
+++ b/packages/examples/ember-app/package.json
@@ -30,7 +30,7 @@
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.19.0",
     "ember-cli-dependency-checker": "^3.2.0",
-    "ember-cli-htmlbars": "^4.2.3",
+    "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3984,6 +3984,19 @@ async-disk-cache@^1.2.1:
     rsvp "^3.0.18"
     username-sync "^1.0.2"
 
+async-disk-cache@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/async-disk-cache/-/async-disk-cache-2.1.0.tgz#e0f37b187ed8c41a5991518a9556d206ae2843a2"
+  integrity sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==
+  dependencies:
+    debug "^4.1.1"
+    heimdalljs "^0.2.3"
+    istextorbinary "^2.5.1"
+    mkdirp "^0.5.0"
+    rimraf "^3.0.0"
+    rsvp "^4.8.5"
+    username-sync "^1.0.2"
+
 async-each@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
@@ -4366,10 +4379,10 @@ babel-plugin-htmlbars-inline-precompile@^1.0.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-1.0.0.tgz#a9d2f6eaad8a3f3d361602de593a8cbef8179c22"
   integrity sha512-4jvKEHR1bAX03hBDZ94IXsYCj3bwk9vYsn6ux6JZNL2U5pvzCWjqyrGahfsGNrhERyxw8IqcirOi9Q6WCo3dkQ==
 
-babel-plugin-htmlbars-inline-precompile@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.0.1.tgz#e1e38a4087f446578e419a21c112530c8df02345"
-  integrity sha512-ZiFY0nQjtdMPGIDwp/5LYOs6rCr54QfcSV5nPbrA7C++Fv4Vb2Q/qrKYx78t+dwmARJztnOBlObFk4z8veHxNA==
+babel-plugin-htmlbars-inline-precompile@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-4.2.1.tgz#9a367f8d7ecb9fb2c2e886edfe285caf7cb9766d"
+  integrity sha512-MCJXk+1R0YjlF/F52eDbhJTpsnqRVYsPYVP9d0jEu7E46AcRPEWDL5tfSweiQWHLKG017BIedATb91KcIoT3zA==
 
 babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.7.0:
   version "2.8.0"
@@ -5043,6 +5056,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.2.0.tgz#e7c6ba82d4f5f5758c26078fe8eea28881233311"
   integrity sha512-bHhs98rj/7i/RZpCSJ3uk55pLXOItjIrh2sRQZSM6OoktScX+LxJzvlU+FELp9j3TdcddTmmYArLSGptCTwjuw==
 
+binaryextensions@^2.1.2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.3.0.tgz#1d269cbf7e6243ea886aa41453c3651ccbe13c22"
+  integrity sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==
+
 bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
@@ -5515,13 +5533,6 @@ broccoli-node-info@^2.1.0:
   resolved "https://registry.yarnpkg.com/broccoli-node-info/-/broccoli-node-info-2.1.0.tgz#ca84560e8570ff78565bea1699866ddbf58ad644"
   integrity sha512-l6qDuboJThHfRVVWQVaTs++bFdrFTP0gJXgsWenczc1PavRVUmL1Eyb2swTAXXMpDOnr2zhNOBLx4w9AxkqbPQ==
 
-broccoli-output-wrapper@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz#f1e0b9b2f259a67fd41a380141c3c20b096828e6"
-  integrity sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==
-  dependencies:
-    heimdalljs-logger "^0.1.10"
-
 broccoli-output-wrapper@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/broccoli-output-wrapper/-/broccoli-output-wrapper-3.2.1.tgz#8f9d1092afe0c1a4b7a1b6f0d2c62f1c403e82ad"
@@ -5570,6 +5581,23 @@ broccoli-persistent-filter@^2.2.1, broccoli-persistent-filter@^2.2.2, broccoli-p
     sync-disk-cache "^1.3.3"
     walk-sync "^1.0.0"
 
+broccoli-persistent-filter@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz#41da6b9577be09a170ecde185f2c5a6099f99c4e"
+  integrity sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==
+  dependencies:
+    async-disk-cache "^2.0.0"
+    async-promise-queue "^1.0.3"
+    broccoli-plugin "^4.0.3"
+    fs-tree-diff "^2.0.0"
+    hash-for-dep "^1.5.0"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    promise-map-series "^0.2.1"
+    rimraf "^3.0.0"
+    symlink-or-copy "^1.0.1"
+    sync-disk-cache "^2.0.0"
+
 broccoli-plugin@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz#73e2cfa05f8ea1e3fc1420c40c3d9e7dc724bf02"
@@ -5600,19 +5628,6 @@ broccoli-plugin@^2.0.0, broccoli-plugin@^2.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz#54ba6dd90a42ec3db5624063292610e326b1e542"
-  integrity sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==
-  dependencies:
-    broccoli-node-api "^1.6.0"
-    broccoli-output-wrapper "^2.0.0"
-    fs-merger "^3.0.1"
-    promise-map-series "^0.2.1"
-    quick-temp "^0.1.3"
-    rimraf "^2.3.4"
-    symlink-or-copy "^1.1.8"
-
 broccoli-plugin@^4.0.1, broccoli-plugin@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-4.0.2.tgz#a16c1f839bc95cc9975437e58864a395e518b447"
@@ -5621,6 +5636,19 @@ broccoli-plugin@^4.0.1, broccoli-plugin@^4.0.2:
     broccoli-node-api "^1.6.0"
     broccoli-output-wrapper "^3.2.1"
     fs-merger "^3.0.1"
+    promise-map-series "^0.2.1"
+    quick-temp "^0.1.3"
+    rimraf "^3.0.0"
+    symlink-or-copy "^1.3.0"
+
+broccoli-plugin@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz#9dcfbfb6a1b27a37cc22e65c071719ce9f92bc1e"
+  integrity sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==
+  dependencies:
+    broccoli-node-api "^1.6.0"
+    broccoli-output-wrapper "^3.2.1"
+    fs-merger "^3.1.0"
     promise-map-series "^0.2.1"
     quick-temp "^0.1.3"
     rimraf "^3.0.0"
@@ -7724,6 +7752,14 @@ editions@^1.1.1:
   resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.4.tgz#3662cb592347c3168eb8e498a0ff73271d67f50b"
   integrity sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==
 
+editions@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/editions/-/editions-2.3.1.tgz#3bc9962f1978e801312fbd0aebfed63b49bfe698"
+  integrity sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==
+  dependencies:
+    errlop "^2.0.0"
+    semver "^6.3.0"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -7902,25 +7938,26 @@ ember-cli-htmlbars@^3.0.1:
     json-stable-stringify "^1.0.1"
     strip-bom "^3.0.0"
 
-ember-cli-htmlbars@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-4.2.3.tgz#ca1a4ce3806594f0a69a1ada3eed749a125cc2bf"
-  integrity sha512-AA5N5a7T+9Bc3m+5X076WFYIN4EQL0o/g8acPBZnEolFJhc3TmnSlWay4JwEuvszA1MLFKmZET/VD9CfRw8+EQ==
+ember-cli-htmlbars@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.3.1.tgz#61793964fc2599ce750db9e972ab55c6dd177c48"
+  integrity sha512-ZjQTt44euDoqLvUkWbt1svgNCXgLzOztEbc2qqYMQvhQig416LMrWK7l3SSbNU+BtLD5UIxmwvLfF1tsO2CVyA==
   dependencies:
     "@ember/edition-utils" "^1.2.0"
-    babel-plugin-htmlbars-inline-precompile "^3.0.1"
+    babel-plugin-htmlbars-inline-precompile "^4.2.0"
     broccoli-debug "^0.6.5"
-    broccoli-persistent-filter "^2.3.1"
-    broccoli-plugin "^3.1.0"
+    broccoli-persistent-filter "^3.1.0"
+    broccoli-plugin "^4.0.3"
     common-tags "^1.8.0"
     ember-cli-babel-plugin-helpers "^1.1.0"
     fs-tree-diff "^2.0.1"
     hash-for-dep "^1.5.1"
     heimdalljs-logger "^0.1.10"
     json-stable-stringify "^1.0.1"
-    semver "^6.3.0"
+    semver "^7.3.2"
+    silent-error "^1.1.1"
     strip-bom "^4.0.0"
-    walk-sync "^2.0.2"
+    walk-sync "^2.2.0"
 
 ember-cli-inject-live-reload@^2.0.2:
   version "2.0.2"
@@ -8573,6 +8610,11 @@ err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
   integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
+
+errlop@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/errlop/-/errlop-2.2.0.tgz#1ff383f8f917ae328bebb802d6ca69666a42d21b"
+  integrity sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -9622,6 +9664,18 @@ fs-merger@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/fs-merger/-/fs-merger-3.0.2.tgz#bf111334b89b8d65b95580d33c587dc79620a4e3"
   integrity sha512-63wmgjPDClP5XcTSKdIXz66X5paYy/m2Ymq5c5YpGxRQEk1HFZ8rtti3LMNSOSw1ketbBMGbSFFcQeEnpnzDpQ==
+  dependencies:
+    broccoli-node-api "^1.7.0"
+    broccoli-node-info "^2.1.0"
+    fs-extra "^8.0.1"
+    fs-tree-diff "^2.0.1"
+    rimraf "^2.6.3"
+    walk-sync "^2.0.2"
+
+fs-merger@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fs-merger/-/fs-merger-3.1.0.tgz#f30f74f6c70b2ff7333ec074f3d2f22298152f3b"
+  integrity sha512-RZ9JtqugaE8Rkt7idO5NSwcxEGSDZpLmVFjtVQUm3f+bWun7JAU6fKyU6ZJUeUnKdJwGx8uaro+K4QQfOR7vpA==
   dependencies:
     broccoli-node-api "^1.7.0"
     broccoli-node-info "^2.1.0"
@@ -11573,6 +11627,15 @@ istextorbinary@2.1.0:
     editions "^1.1.1"
     textextensions "1 || 2"
 
+istextorbinary@^2.5.1:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/istextorbinary/-/istextorbinary-2.6.0.tgz#60776315fb0fa3999add276c02c69557b9ca28ab"
+  integrity sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==
+  dependencies:
+    binaryextensions "^2.1.2"
+    editions "^2.2.0"
+    textextensions "^2.5.0"
+
 isurl@^1.0.0-alpha5:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isurl/-/isurl-1.0.0.tgz#b27f4f49f3cdaa3ea44a0a5b7f3462e6edc39d67"
@@ -12348,6 +12411,13 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 macos-release@^2.2.0:
   version "2.3.0"
@@ -15751,6 +15821,13 @@ semver@^7.1.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.2.2.tgz#d01432d74ed3010a20ffaf909d63a691520521cd"
   integrity sha512-Zo84u6o2PebMSK3zjJ6Zp5wi8VnQZnEaCP13Ul/lt1ANsLACxnJxq4EEm1PY94/por1Hm9+7xpIswdS5AkieMA==
 
+semver@^7.3.2:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
@@ -16710,6 +16787,17 @@ sync-disk-cache@^1.3.3:
     rimraf "^2.2.8"
     username-sync "^1.0.2"
 
+sync-disk-cache@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz#01e879edc41c34a01fcdda5b39d47dd496e154a6"
+  integrity sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==
+  dependencies:
+    debug "^4.1.1"
+    heimdalljs "^0.2.6"
+    mkdirp "^0.5.0"
+    rimraf "^3.0.0"
+    username-sync "^1.0.2"
+
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
@@ -16886,7 +16974,7 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-"textextensions@1 || 2":
+"textextensions@1 || 2", textextensions@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.6.0.tgz#d7e4ab13fe54e32e08873be40d51b74229b00fc4"
   integrity sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ==
@@ -17677,6 +17765,16 @@ walk-sync@^2.0.0, walk-sync@^2.0.2:
     "@types/minimatch" "^3.0.3"
     ensure-posix-path "^1.1.0"
     matcher-collection "^2.0.0"
+
+walk-sync@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-2.2.0.tgz#80786b0657fcc8c0e1c0b1a042a09eae2966387a"
+  integrity sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==
+  dependencies:
+    "@types/minimatch" "^3.0.3"
+    ensure-posix-path "^1.1.0"
+    matcher-collection "^2.0.0"
+    minimatch "^3.0.4"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
**Why**
In the current babel-plugin implementation we were extracting scope variables only from the program scope and hence never had access to components defined in local private functional scopes

**How**
- Check for bindings from current path
- Added a test to verify behavior