### PR TITLE
Add owner to RenderOptions

### DIFF
--- a/packages/@glimmerx/core/src/renderComponent.ts
+++ b/packages/@glimmerx/core/src/renderComponent.ts
@@ -6,7 +6,7 @@ import {
 import { Dict } from '@glimmer/interfaces';
 import Owner from './owner';
 
-export interface RenderComponentOptions extends Omit<GlimmerJsRenderComponentOptions, 'owner'> {
+export interface RenderComponentOptions extends GlimmerJsRenderComponentOptions {
   services?: Dict<unknown>;
 }
 
@@ -26,9 +26,15 @@ export default function renderComponent(
     return glimmerJsRenderComponent(ComponentClass, optionsOrElement);
   }
 
-  const { element, args, services, rehydrate } = optionsOrElement;
+  const { element, args, owner: maybeOwner, services, rehydrate } = optionsOrElement;
 
-  const owner = new Owner(services ?? {});
+  // service option should be removed on next "major bump"
+  const owner = maybeOwner || new Owner(services ?? {});
 
-  return glimmerJsRenderComponent(ComponentClass, { element, args, owner, rehydrate });
+  return glimmerJsRenderComponent(ComponentClass, {
+    element,
+    args,
+    owner,
+    rehydrate,
+  });
 }

--- a/packages/@glimmerx/service/index.ts
+++ b/packages/@glimmerx/service/index.ts
@@ -1,3 +1,9 @@
 export { service } from './src/decorator';
 
-export default class Service {}
+import { OWNER } from '@glimmer/owner';
+
+export default class Service {
+  constructor(owner) {
+    this[OWNER] = owner;
+  }
+}

--- a/packages/@glimmerx/ssr/src/render.ts
+++ b/packages/@glimmerx/ssr/src/render.ts
@@ -6,15 +6,15 @@ import {
 import { Dict } from '@glimmer/interfaces';
 import { ComponentDefinition, Owner } from '@glimmerx/core';
 
-export interface RenderOptions extends Omit<GlimmerJsRenderOptions, 'owner'> {
+export interface RenderOptions extends GlimmerJsRenderOptions {
   services?: Dict<unknown>;
 }
 
 export function renderToString(
   definition: ComponentDefinition,
-  { args, serializer, services, rehydrate }: RenderOptions = {}
+  { args, serializer, owner: maybeOwner, services, rehydrate }: RenderOptions = {}
 ): Promise<string> {
-  const owner = new Owner(services ?? {});
+  const owner = maybeOwner instanceof Owner ? maybeOwner : new Owner(services ?? {});
 
   return glimmerJsRenderToString(definition, { args, serializer, owner, rehydrate });
 }
@@ -22,9 +22,9 @@ export function renderToString(
 export function renderToStream(
   stream: NodeJS.WritableStream,
   definition: ComponentDefinition,
-  { args, serializer, services, rehydrate }: RenderOptions = {}
+  { args, serializer, owner: maybeOwner, services, rehydrate }: RenderOptions = {}
 ): void {
-  const owner = new Owner(services ?? {});
+  const owner = maybeOwner instanceof Owner ? maybeOwner : new Owner(services ?? {});
 
   glimmerJsRenderToStream(stream, definition, { args, serializer, owner, rehydrate });
 }

--- a/packages/@glimmerx/ssr/tests/lib/LazyOwner.ts
+++ b/packages/@glimmerx/ssr/tests/lib/LazyOwner.ts
@@ -1,0 +1,39 @@
+import { Dict } from '@glimmer/interfaces';
+import { FactoryIdentifier, Owner } from '@glimmerx/core';
+
+const SERVICES = Symbol('Services');
+
+// Extending owner but we don't really use anything from base class.
+export default class LazyOwner extends Owner {
+  private [SERVICES]: Dict<unknown>;
+  private delegate;
+
+  constructor(delegate: Dict<unknown>) {
+    super({}); // This is a hack, because we don't want to use the parent classes services.
+    this[SERVICES] = {};
+    this.delegate = delegate;
+  }
+
+  lookup({ type, name }: FactoryIdentifier) {
+    if (type !== 'service') {
+      throw new Error('The only supported lookups are for services');
+    }
+
+    if (this[SERVICES][name]) {
+      return this[SERVICES][name];
+    }
+
+    if (this[SERVICES][name] === undefined) {
+      if (!this.delegate[name]) {
+        throw new Error(
+          `Unable to lookup service '${name}', but it did not exist. Did you pass it to the render method.`
+        );
+      }
+      const ServiceClassRef = this.delegate[name];
+
+      this[SERVICES][name] = new ServiceClassRef(this);
+    }
+
+    return this[SERVICES][name];
+  }
+}

--- a/packages/@glimmerx/ssr/tests/render-options-tests.ts
+++ b/packages/@glimmerx/ssr/tests/render-options-tests.ts
@@ -3,6 +3,8 @@ import HTMLSerializer from '@simple-dom/serializer';
 import voidMap from '@simple-dom/void-map';
 import { SerializableNode } from '@simple-dom/interface';
 import { renderToString, RenderOptions } from '..';
+import { service } from '@glimmerx/service';
+import { Owner } from '@glimmerx/core';
 
 QUnit.module('@glimmer/ssr rendering', () => {
   QUnit.test('options.serializer', async (assert) => {
@@ -21,5 +23,38 @@ QUnit.module('@glimmer/ssr rendering', () => {
     const output = await renderToString(MyComponent, options);
 
     assert.equal(output, '<h1>Goodbye World</h1>');
+  });
+  QUnit.test('options.owner', async (assert) => {
+    class LocaleService {
+      get currentLocale() {
+        return 'en_US';
+      }
+    }
+
+    class InvalidLocaleService extends LocaleService {
+      get currentLocale() {
+        return 'xx_YY';
+      }
+    }
+
+    class MyComponent extends Component {
+      static template = hbs`<h1>{{this.myLocale}}</h1>`;
+
+      @service locale: LocaleService;
+
+      get myLocale() {
+        return this.locale.currentLocale;
+      }
+    }
+
+    const owner = new Owner({
+      locale: new LocaleService(),
+    });
+
+    const options: RenderOptions = { owner, services: { locaele: new InvalidLocaleService() } };
+
+    const output = await renderToString(MyComponent, options);
+
+    assert.equal(output, '<h1>en_US</h1>');
   });
 });

--- a/packages/@glimmerx/ssr/tests/render-options-tests.ts
+++ b/packages/@glimmerx/ssr/tests/render-options-tests.ts
@@ -3,8 +3,9 @@ import HTMLSerializer from '@simple-dom/serializer';
 import voidMap from '@simple-dom/void-map';
 import { SerializableNode } from '@simple-dom/interface';
 import { renderToString, RenderOptions } from '..';
-import { service } from '@glimmerx/service';
+import Service, { service } from '@glimmerx/service';
 import { Owner } from '@glimmerx/core';
+import LazyOwner from './lib/LazyOwner';
 
 QUnit.module('@glimmer/ssr rendering', () => {
   QUnit.test('options.serializer', async (assert) => {
@@ -31,7 +32,7 @@ QUnit.module('@glimmer/ssr rendering', () => {
       }
     }
 
-    class InvalidLocaleService extends LocaleService {
+    class InvalidLocaleService {
       get currentLocale() {
         return 'xx_YY';
       }
@@ -52,6 +53,57 @@ QUnit.module('@glimmer/ssr rendering', () => {
     });
 
     const options: RenderOptions = { owner, services: { locaele: new InvalidLocaleService() } };
+
+    const output = await renderToString(MyComponent, options);
+
+    assert.equal(output, '<h1>en_US</h1>');
+  });
+  QUnit.test('options.owner Nested Services with LazyOwner', async (assert) => {
+    const ctx = Object.freeze({
+      locale: 'en_US',
+    });
+
+    class RequestContext extends Service {
+      static from(ctx) {
+        return class extends this {
+          context = ctx;
+        };
+      }
+    }
+
+    class Play extends Service {
+      @service request;
+
+      get locale() {
+        return this.request.context.locale;
+      }
+    }
+
+    class Locale extends Service {
+      @service play;
+      get currentLocale() {
+        return this.play.locale;
+      }
+    }
+
+    class MyComponent extends Component {
+      static template = hbs`<h1>{{this.myLocale}}</h1>`;
+
+      @service locale: Locale;
+      get myLocale() {
+        return this.locale.currentLocale;
+      }
+    }
+
+    const owner = new LazyOwner({
+      request: RequestContext.from(ctx),
+      play: Play,
+      locale: Locale,
+    });
+
+    const options: RenderOptions = {
+      owner,
+    };
 
     const output = await renderToString(MyComponent, options);
 


### PR DESCRIPTION
Goals
- Primary goal, optionally pass Owner to render methods
- Secondary goal, have a `service` become decorated by another service.

Overall the service decorated by a service works.

The missing piece was instantiating services with the owner in the base class.

This aligns with the [current ember implementation for a service since the constructor inherited CoreObject](https://api.emberjs.com/ember/3.24/classes/Service/properties?show=inherited%2Cprotected%2Cprivate)

Some things that should be done to improve this:
- Create an `Owner` interface so that we don't have to extend and call `super()` in this LazyOwner implementation.
- We can refactor the Owner in this case, such that when the `lookup()` happens for a service, and the `someService instanceof Service` is `true` we can pass the owner into the constructor of the service, otherwise we use the existing instance defined in the service map.