### PR TITLE
Improve services API

### DIFF
--- a/packages/@glimmerx/service/index.ts
+++ b/packages/@glimmerx/service/index.ts
@@ -1,3 +1,9 @@
 export { service } from './src/decorator';
 
-export default class Service {}
+import { setOwner } from '@glimmerx/core';
+
+export default class Service {
+  constructor(owner) {
+    setOwner(this, owner);
+  }
+}

--- a/packages/@glimmerx/ssr/tests/render-options-tests.ts
+++ b/packages/@glimmerx/ssr/tests/render-options-tests.ts
@@ -3,6 +3,7 @@ import HTMLSerializer from '@simple-dom/serializer';
 import voidMap from '@simple-dom/void-map';
 import { SerializableNode } from '@simple-dom/interface';
 import { renderToString, RenderOptions } from '..';
+import Service, { service } from '@glimmerx/service';
 
 QUnit.module('@glimmer/ssr rendering', () => {
   QUnit.test('options.serializer', async (assert) => {
@@ -21,5 +22,66 @@ QUnit.module('@glimmer/ssr rendering', () => {
     const output = await renderToString(MyComponent, options);
 
     assert.equal(output, '<h1>Goodbye World</h1>');
+  });
+
+  QUnit.test('options.services', async (assert) => {
+    const ctx = Object.freeze({
+      locale: 'en_US',
+    });
+
+    class Meta {
+      id;
+
+      constructor(id) {
+        this.id = id;
+      }
+    }
+
+    const meta = new Meta('ABC123');
+
+    class Request extends Service {
+      @service context;
+
+      get locale() {
+        return this.context.locale;
+      }
+    }
+
+    class Locale extends Service {
+      @service request;
+
+      get currentLocale() {
+        return this.request.locale;
+      }
+    }
+
+    class MyComponent extends Component {
+      static template = hbs`<h1>{{this.myLocale}},{{this.metaId}}</h1>`;
+
+      @service locale: Locale;
+      @service meta: Meta;
+
+      get myLocale() {
+        return this.locale.currentLocale;
+      }
+      get metaId() {
+        return this.meta.id;
+      }
+    }
+
+    const services = {
+      context: ctx, // Pojo
+      request: Request, // Constructor
+      locale: Locale, // Constructor,
+      meta: meta,
+    };
+
+    const options: RenderOptions = {
+      services,
+    };
+
+    const output = await renderToString(MyComponent, options);
+
+    assert.equal(output, '<h1>en_US,ABC123</h1>');
   });
 });


### PR DESCRIPTION
- `Owner` has been updated to late bind services in the dictionary of services until the `lookup()` method is called. 
- `Service` class now has a constructor with a single argument for an `owner` to be passed in, so that it can be bound  to the object instance. Doing this allows for services to be decorated with other services.
- The `services` property for the options object that is passed into `renderComponent` and `renderToString` methods now allows for either an pojo, constructor, or a `Service`. If the value in the service map is of type `Service` it can be decorated with services. 