### PR TITLE
Add Compiler Package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,10 +8,7 @@ module.exports = {
   env: {
     es6: true,
   },
-  extends: [
-    'eslint:recommended',
-    'plugin:prettier/recommended',
-  ],
+  extends: ['eslint:recommended', 'plugin:prettier/recommended'],
   plugins: ['@typescript-eslint', '@glimmerx', 'prettier'],
   rules: {
     '@glimmerx/template-vars': 'error',
@@ -32,6 +29,7 @@ module.exports = {
         '**/bin/**/*.js',
         '**/scripts/**/*.js',
         '**/blueprints/**/*.js',
+        '**/compiler/**/*.js',
         'webpack.config.js',
         'packages/@glimmerx/blueprint/index.js',
       ],
@@ -72,12 +70,15 @@ module.exports = {
         '@typescript-eslint/explicit-function-return-type': 'error',
         '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
 
-        '@typescript-eslint/ban-types': ['error', {
-          types: {
-            // we currently use `object` as "valid WeakMap key" in a lot of APIs
-            object: false,
-          }
-        }],
+        '@typescript-eslint/ban-types': [
+          'error',
+          {
+            types: {
+              // we currently use `object` as "valid WeakMap key" in a lot of APIs
+              object: false,
+            },
+          },
+        ],
 
         // We should try to remove this eventually
         '@typescript-eslint/explicit-function-return-type': 'off',
@@ -90,7 +91,7 @@ module.exports = {
         '@typescript-eslint/no-non-null-assertion': 'off',
 
         '@typescript-eslint/no-use-before-define': 'off',
-      }
+      },
     },
   ],
 };

--- a/packages/@glimmerx/compiler/index.js
+++ b/packages/@glimmerx/compiler/index.js
@@ -1,0 +1,2 @@
+const compiler = require('@glimmer/compiler');
+module.exports.precompile = compiler.precompile;

--- a/packages/@glimmerx/compiler/package.json
+++ b/packages/@glimmerx/compiler/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@glimmerx/compiler",
+  "version": "0.6.0",
+  "description": "Compiler functionality",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/modules/index.js",
+  "repository": "https://github.com/glimmerjs/glimmer-experimental",
+  "author": "Tom Dale <tom@tomdale.net>",
+  "license": "MIT",
+  "private": false,
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "build": "webpack"
+  },
+  "dependencies": {
+    "@glimmer/compiler": "0.73.0"
+  },
+  "volta": {
+    "node": "12.10.0",
+    "yarn": "1.22.4"
+  }
+}


### PR DESCRIPTION
When we landed the preset and webpack loader we lost the re-export of
the precompile function. This introduces a re-exporting compiler package
to ensure consumers can run on the same compiler/runtime combo.