### PR TITLE
Pass the actual preset env instance to babel in the playground

### DIFF
--- a/packages/examples/playground/src/utils/compile.ts
+++ b/packages/examples/playground/src/utils/compile.ts
@@ -2,6 +2,7 @@ declare const Babel: any;
 
 import glimmerXPreset from '@glimmerx/babel-preset';
 import { precompile } from '@glimmer/compiler';
+import babelPresetEnv from '@babel/preset-env';
 
 export default function compile(js: string): { code: string } {
   return Babel.transform(js, {
@@ -9,7 +10,7 @@ export default function compile(js: string): { code: string } {
     presets: [
       [glimmerXPreset, { __loadPlugins: true, precompile }],
       [
-        'env',
+        babelPresetEnv,
         {
           targets: [
             'last 2 Edge versions',


### PR DESCRIPTION
### Why
The playground is currently broken with a misconfigured babel option

### How
- Pass the actual preset-env instance so that webpack bundles it in instead of looking it up at runtime