### PR TITLE
Change all glimmer-vm dependencies to be consitent at 0.77.6

### DIFF
--- a/packages/@glimmerx/core/package.json
+++ b/packages/@glimmerx/core/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@glimmer/core": "2.0.0-beta.17",
-    "@glimmer/interfaces": "0.77.3",
-    "@glimmer/manager": "0.77.3"
+    "@glimmer/interfaces": "0.77.6",
+    "@glimmer/manager": "0.77.6"
   },
   "volta": {
     "node": "12.10.0",

--- a/packages/@glimmerx/eslint-plugin/package.json
+++ b/packages/@glimmerx/eslint-plugin/package.json
@@ -20,7 +20,7 @@
     "mocha": "^7.1.1"
   },
   "peerDependencies": {
-    "@glimmer/syntax": "^0.77.5",
+    "@glimmer/syntax": "^0.77.6",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.29.0"
   },

--- a/packages/@glimmerx/helper/package.json
+++ b/packages/@glimmerx/helper/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@glimmerx/core": "0.6.5",
     "@glimmer/helper": "2.0.0-beta.17",
-    "@glimmer/interfaces": "0.77.3",
+    "@glimmer/interfaces": "0.77.6",
     "ember-cli-babel": "7.26.2"
   },
   "volta": {

--- a/packages/@glimmerx/ssr/package.json
+++ b/packages/@glimmerx/ssr/package.json
@@ -15,7 +15,7 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@glimmer/interfaces": "0.77.3",
+    "@glimmer/interfaces": "0.77.6",
     "@glimmer/ssr": "2.0.0-beta.17",
     "@glimmerx/core": "^0.6.5"
   },

--- a/packages/@glimmerx/webpack-loader/package.json
+++ b/packages/@glimmerx/webpack-loader/package.json
@@ -10,7 +10,7 @@
     "test": "mocha -r esm"
   },
   "dependencies": {
-    "@glimmer/syntax": "0.77.5",
+    "@glimmer/syntax": "0.77.6",
     "validate-peer-dependencies": "^1.1.0",
     "loader-utils": "2.0.0",
     "schema-utils": "3.0.0"

--- a/packages/examples/basic/package.json
+++ b/packages/examples/basic/package.json
@@ -17,7 +17,7 @@
     "basic-addon": "0.6.5"
   },
   "devDependencies": {
-    "@glimmer/interfaces": "0.77.3",
+    "@glimmer/interfaces": "0.77.6",
     "@glimmerx/storybook": "^0.6.5",
     "@storybook/addon-essentials": "^6.1.21"
   },


### PR DESCRIPTION
### Why
Some glimmer-vm packages were at an inconsistent version which was causing issues when used in an environment where dependencies are not deduped for e.g. node 

### How
- Change all inconsistent packages to v0.77.6