### PR TITLE
bugfix: #issue-141 fix incorrect render issue of template tag

### DIFF
--- a/packages/@glimmerx/storybook/src/client/preview/render.ts
+++ b/packages/@glimmerx/storybook/src/client/preview/render.ts
@@ -26,6 +26,19 @@ export default function renderMain({ storyFn, showMain }: RenderMainArgs) {
     glimmerStoryComponent = storyFnResult;
   }
 
+  /**
+   * Fix an issue with template tag where the actual element is inserted as a sibling instead of being a child of #document-fragment
+   * Wrap this inside of window.onload for the iframe to finish
+   */
+  window.addEventListener('load', () => {
+    rootElement.querySelectorAll('template').forEach((element: HTMLTemplateElement) => {
+      const { firstElementChild } = element;
+      if (firstElementChild) {
+        element.content.append(firstElementChild);
+      }
+    });
+  });
+
   rootElement.innerHTML = '';
   showMain();
   return renderComponent(glimmerStoryComponent, glimmerRenderComponentOptions);


### PR DESCRIPTION
resolve #141 

### Description ###
- Fix an issue with template tag where the actual element is inserted as a sibling instead of being a child of #document-fragment
### Screenshots ###
<img width="827" alt="Screen Shot 2022-02-15 at 5 00 24 PM" src="https://user-images.githubusercontent.com/4967217/154176116-ce862fef-4144-4438-941c-255d9c3a76bf.png">
 