### PR TITLE
WIP Expand the template-vars eslint rule to handle local methods

### DIFF
--- a/packages/@glimmerx/eslint-plugin/lib/helpers/getThisTemplateLocals.js
+++ b/packages/@glimmerx/eslint-plugin/lib/helpers/getThisTemplateLocals.js
@@ -1,0 +1,40 @@
+const { preprocess, traverse } = require('@glimmer/syntax');
+
+/**
+ * Adds tokens to the tokensSet if they're a path prefixed with `this.`
+ */
+
+function addTokens(tokensSet, node) {
+  if (node.type === 'PathExpression') {
+    if (node.this === true) {
+      // this will only look at the first level of methods on this, with no handling for (properties/methods) of methods
+      const topLevelMaybeToken = node.parts[0];
+
+      if (tokensSet.has(topLevelMaybeToken) === false) {
+        tokensSet.add(topLevelMaybeToken);
+      }
+    }
+  }
+}
+
+/**
+ * Parses and traverses a given handlebars html template to extract all references to local methods via `this.myMethod`
+ */
+
+export default function getThisTemplateLocals(html) {
+  const ast = preprocess(html);
+  const tokensSet = new Set();
+  traverse(ast, {
+    ElementNode(node) {
+      addTokens(tokensSet, node);
+    },
+
+    PathExpression(node) {
+      addTokens(tokensSet, node);
+    }
+  });
+  let tokens = [];
+  tokensSet.forEach(s => tokens.push(s));
+
+  return tokens;
+}

--- a/packages/@glimmerx/eslint-plugin/lib/rules/template-vars.js
+++ b/packages/@glimmerx/eslint-plugin/lib/rules/template-vars.js
@@ -1,15 +1,17 @@
 const { getTemplateLocals } = require('@glimmer/syntax');
+import getThisTemplateLocals from '../helpers/getThisTemplateLocals';
 
 module.exports = {
   docs: {
     description:
-      'Components / Helpers referenced in hbs template literals should not trigger no-unused-vars failures, but should trigger no-undef if they are not defined propery',
+      'Components / Helpers referenced in hbs template literals should not trigger no-unused-vars failures, but should trigger template-vars if they are not defined propery',
     category: 'Variables',
     recommended: true,
   },
   meta: {
     messages: {
       undefToken: 'Token {{ token }} is used in an hbs tagged template literal, but is not defined',
+      undefLocalMethod: 'Local Method {{ method }} is used in an hbs tagged template literal, but is not defined',
     },
     // example: '@glimmerx/glimmerx/template-vars': [2, 'unused-only', { nativeTokens: ['anImplicitToken'] }]
     schema: [
@@ -41,7 +43,8 @@ module.exports = {
 
     const [mode = 'all', configOpts] = context.options;
     let nativeTokens = (configOpts && configOpts.nativeTokens) || [];
-
+    let localUsedMethods = [];
+    let localDefinedMethods = [];
     return {
       ImportSpecifier(node) {
         if (isGlimmerSfc || node.parent.source.value !== '@glimmerx/component') {
@@ -62,6 +65,8 @@ module.exports = {
         const templateString = templateElementNode.value.raw;
 
         const templateScopeTokens = getTemplateLocals(templateString);
+        localUsedMethods = localUsedMethods.concat(getThisTemplateLocals(templateString));
+
         templateScopeTokens.forEach((token) => {
           const isTokenPresent = context.markVariableAsUsed(token);
           if (!isTokenPresent && !nativeTokens.includes(token) && mode === 'all') {
@@ -75,6 +80,25 @@ module.exports = {
           }
         });
       },
+      MethodDefinition(node) {
+        localDefinedMethods.push(node.key.name);
+      },
+      "ClassBody:exit"(node) {
+        let localUndefinedMethods = localUsedMethods.filter(method => !localDefinedMethods.includes(method));
+        localUndefinedMethods.forEach((method) => {
+          context.report({
+            data: {
+              method,
+            },
+            messageId: 'undefLocalMethod',
+            node: node,
+          });
+        });
+        localUsedMethods = [];
+        localDefinedMethods = [];
+
+        //TODO: this assumes 1 class body, and cannot handle nested classes
+      }
     };
   },
 };

--- a/packages/@glimmerx/eslint-plugin/test/lib/rules/template-vars.js
+++ b/packages/@glimmerx/eslint-plugin/test/lib/rules/template-vars.js
@@ -131,8 +131,8 @@ describe('no-unused-vars', function () {
       import { hbs as notHbs } from '@glimmerx/component';
       import myHelper from './myHelper';
       export default class Component {
-        static template = hbs\`I am using {{myHelper}} here, but I forgot to import hbs,
-          and also forgot to tag this template literal with hbs.\`;
+        static template = hbs\`I am using {{myHelper}} here, but I imported hbs under a different local name,
+        and tagged this template literal with hbs rather than its local name.\`;
         method() {
           return false;
         }
@@ -283,7 +283,7 @@ ruleTester.run('template-vars', rule, {
       code: `
         import { hbs } from '@glimmerx/component';
         export default class Component {
-          static template = hbs\`I am using {{myHelper}} here, but I forgot to tag this template literal with hbs.\`;
+          static template = hbs\`I am using {{myHelper}} here, but I forgot to import myHelper.\`;
           method() {
             return false;
           }
@@ -296,6 +296,46 @@ ruleTester.run('template-vars', rule, {
         },
       ],
       options: ['all'],
+    },
+    {
+      code: `
+        import { hbs } from '@glimmerx/component';
+        export default class Component {
+          static template = hbs\`I am using {{this.myHelper}} here, but I forgot to define myHelper.\`;
+          method() {
+            return false;
+          }
+          test = true;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'undefLocalMethod',
+        },
+      ],
+      options: ['all'],
+    },
+    {
+      code: `
+        import { hbs } from '@glimmerx/component';
+        import foo3 from './foo3';
+        export default class Component {
+          static template = hbs\`I am using {{this.foo1.bar}} and {{this.foo3}} here, but I forgot to define foo3 even though I imported a different foo3.\`;
+
+          get foo1() {
+            return 1;
+          }
+
+          get foo2() {
+            return 2;
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'undefLocalMethod',
+        },
+      ],
     },
   ],
 });


### PR DESCRIPTION
Expand the template-vars eslint rule to handle local methods referenced with `this.` in hbs templates
Note that this currently can't handle nested Classes, and will not check for properties/methods of objects returned by local methods

Also cleaned up some errors in the original testing/documentation